### PR TITLE
Handle errors when loading message

### DIFF
--- a/app/page.js
+++ b/app/page.js
@@ -1,14 +1,22 @@
 import prisma from '@/lib/prisma';
 
 export default async function Home() {
-  const msg = await prisma.message.findFirst({
-    orderBy: { createdAt: 'asc' },
-    select: { text: true },
-  });
+  let message;
+
+  try {
+    const msg = await prisma.message.findFirst({
+      orderBy: { createdAt: 'asc' },
+      select: { text: true },
+    });
+    message = msg?.text ?? 'No message found';
+  } catch (error) {
+    console.error('Error fetching message:', error);
+    message = 'No message found';
+  }
 
   return (
     <main style={{ padding: 32 }}>
-      <h1>{msg?.text ?? 'No message found'}</h1>
+      <h1>{message}</h1>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- wrap `prisma.message.findFirst` in a try/catch
- fall back to "No message found" when errors occur

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689faacd8f90832f9398350e57993814