### PR TITLE
Use upsert in seed script

### DIFF
--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -2,7 +2,11 @@ import { PrismaClient } from '@prisma/client';
 const prisma = new PrismaClient();
 
 async function main() {
-  await prisma.message.create({ data: { text: 'Hello World' } });
+  await prisma.message.upsert({
+    where: { id: 1 },
+    update: { text: 'Hello World' },
+    create: { id: 1, text: 'Hello World' },
+  });
   console.log('Seeded: Hello World');
 }
 


### PR DESCRIPTION
## Summary
- use `prisma.message.upsert` for seeding initial message

## Testing
- `npx prisma migrate deploy`
- `npx prisma generate`
- `node prisma/seed.js`
- `node prisma/seed.js`
- `psql -U root -d tullyelly -c 'SELECT * FROM "Message";'`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689faacf1b1c832fbf346354cf7a578c