### PR TITLE
Configure Node as ES module

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "tullyelly",
   "version": "0.1.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "dev": "next dev --turbopack",
     "build": "next build",


### PR DESCRIPTION
## Summary
- set package.json `type` to `module` so Node treats `.js` files as ES modules

## Testing
- `npm install --package-lock-only`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689faac6180c832fbb8213be7988f37e