### PR TITLE
chore: generate Prisma client before build

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "next dev --turbopack",
-    "build": "next build",
+    "postinstall": "prisma generate",
+    "build": "prisma generate && next build",
     "start": "next start",
     "lint": "next lint"
   },


### PR DESCRIPTION
## Summary
- run `prisma generate` automatically when installing
- ensure Prisma client is generated before `next build`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689fcad96168832fbb392dac1fab3308