### PR TITLE
Specify Node.js runtime for home page

### DIFF
--- a/app/page.js
+++ b/app/page.js
@@ -1,3 +1,4 @@
+export const runtime = 'nodejs';
 import prisma from '@/lib/prisma';
 
 export default async function Home() {


### PR DESCRIPTION
## Summary
- define Node.js runtime for `app/page.js` to ensure server-side execution

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689fcafcfef0832fa1339050d4f2ff1c