### PR TITLE
Add hug-ball celebration page

### DIFF
--- a/app/hug-ball/page.js
+++ b/app/hug-ball/page.js
@@ -1,0 +1,17 @@
+import Image from 'next/image';
+
+export default function HugBallPage() {
+  return (
+    <main style={{ padding: 32 }}>
+      <h1>We made it to Vercel!</h1>
+      <p>I love you all. Hug ball.</p>
+      <Image
+        src="https://placehold.co/600x400?text=Hug+Ball"
+        alt="Fellas hugging"
+        width={600}
+        height={400}
+        style={{ maxWidth: '100%', height: 'auto' }}
+      />
+    </main>
+  );
+}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,13 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'placehold.co',
+      },
+    ],
+  },
+};
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- add `/hug-ball` page to celebrate the Vercel migration
- embed hug-ball image from external source and permit remote images

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689fdc9a7df4832fa238b60e9702373b