### PR TITLE
Clarify Prisma client reuse comment for non-production environments

### DIFF
--- a/lib/prisma.js
+++ b/lib/prisma.js
@@ -1,6 +1,6 @@
 import { PrismaClient } from '@prisma/client';
 
-// Reuse a single PrismaClient instance in dev to avoid exhausting connections
+// Reuse a single PrismaClient instance in non-production environments to avoid exhausting connections
 const globalForPrisma = globalThis;
 
 const prisma = globalForPrisma.prisma || new PrismaClient();


### PR DESCRIPTION
## Summary
- clarify Prisma client reuse comment for non-production environments

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689fbdeed6a4832fa270ed53d2dcc573