### PR TITLE
Add Hug Ball launch page without binary image

### DIFF
--- a/app/hug-ball/page.js
+++ b/app/hug-ball/page.js
@@ -1,0 +1,22 @@
+import Image from "next/image";
+
+export const metadata = {
+  title: "Hug Ball — tullyelly.com",
+  description: "Fellas, we launched.",
+};
+
+export default function HugBallPage() {
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        padding: "1rem",
+      }}
+    >
+      <Image src="/hug-ball-test.png" alt="Hug Ball" width={720} height={1280} />
+      <p>Fellas, we launched.</p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `/hug-ball` page that displays `hug-ball-test.png` with caption and metadata
- remove `public/hug-ball-test.png` to avoid committing binary files

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ff6f7a4d4832f9324b6960631fb29