### PR TITLE
Normalize hero image paths to avoid Next.js 400 [WU-178]

### DIFF
--- a/app/_sanity/image-check/page.tsx
+++ b/app/_sanity/image-check/page.tsx
@@ -1,0 +1,27 @@
+/* eslint-disable @next/next/no-img-element */
+import Image from 'next/image';
+
+export const metadata = {
+  title: 'Image Sanity Check',
+};
+
+export default function Page() {
+  return (
+    <article className="section" aria-labelledby="title">
+      <h1 id="title">Image Sanity Check</h1>
+      <p>Raw &lt;img&gt; below should match Next.js Image.</p>
+      <img
+        src="/images/optimized/cardattack.webp"
+        width="1200"
+        height="675"
+        alt="raw control"
+      />
+      <Image
+        src="/images/optimized/cardattack.webp"
+        alt="next-image"
+        width={1200}
+        height={675}
+      />
+    </article>
+  );
+}

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -10,10 +10,11 @@ interface HeroProps {
 }
 
 export default function Hero({ src, alt, width, height, caption, priority = true }: HeroProps) {
+  const normalizedSrc = src.startsWith('/') ? src : `/${src}`;
   return (
     <figure>
       <Image
-        src={src}
+        src={normalizedSrc}
         alt={alt}
         width={width}
         height={height}

--- a/docs/images.md
+++ b/docs/images.md
@@ -1,0 +1,6 @@
+# Image Guidelines
+
+- Optimized assets live under `public/images/optimized` and are committed to the repo.
+- Paths passed to `<Image>` or `<img>` must start with a leading slash (e.g. `/images/optimized/cardattack.webp`).
+- When a request to `/_next/image` fails, the response body describes the problem (e.g., `"url" parameter is invalid`).
+- During debugging you can bypass optimization with the `unoptimized` prop on `next/image`.


### PR DESCRIPTION
## Summary
- sanitize `Hero` image paths to ensure a leading slash
- add `/app/_sanity/image-check` page to verify `<img>` vs `next/image`
- document image expectations and troubleshooting in `docs/images.md`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Environment variable not found: DATABASE_URL)*


------
https://chatgpt.com/codex/tasks/task_e_68a559358330832e96c43a6bdf9aade6