### PR TITLE
feat: add global header system

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -11,7 +11,15 @@
   --cream: #EEE1C6;            /* Cream City Cream */
   --blue: #0077C0;             /* Great Lakes Blue */
   --blue-contrast: #0069A9;    /* Darkened for AA on cream */
+  --blue-header: #005990;      /* Darkened for AAA header fill */
   --green: #00471B;            /* Bucks Green */
+  --header-fg: #FFFFFF;
+  --header-fg-muted: rgba(255,255,255,.85);
+  --header-focus: color-mix(in srgb, white 85%, var(--blue-header));
+  --rail-bg: var(--green);
+  --rail-fg: #FFFFFF;
+  --header-bg-transparent: rgba(0,0,0,.25); /* fallback tint when transparent */
+  --header-bg-solid: var(--blue-header);
 
   /* Neutrals for readability */
   --white: #FFFFFF;
@@ -211,7 +219,6 @@ p {
   border-top: 1px solid var(--border-subtle);
 }
 
-.header,
 .footer {
   padding: 1rem 0;
 }
@@ -227,4 +234,75 @@ p {
   overflow: hidden;
   clip: rect(1px, 1px, 1px, 1px);
   white-space: nowrap;
+}
+
+/* Announcement rail */
+.site-rail {
+  background: var(--rail-bg);
+  color: var(--rail-fg);
+  font-size: 0.875rem;
+}
+
+.site-rail .rail-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem 1rem;
+}
+
+.site-rail button {
+  background: none;
+  border: 0;
+  color: var(--rail-fg);
+  cursor: pointer;
+}
+
+/* Global header */
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+  background: var(--header-bg-solid);
+  color: var(--header-fg);
+  border-bottom: 1px solid rgba(255,255,255,0.2);
+  transition: background 0.3s ease-out, border-color 0.3s ease-out;
+  height: 64px;
+}
+
+@media (max-width: 768px) {
+  .site-header {
+    height: 56px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .site-header {
+    transition: none;
+  }
+}
+
+.site-header.transparent {
+  background: var(--header-bg-transparent);
+  border-bottom-color: rgba(255,255,255,0.4);
+}
+
+.site-header .header-inner {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  height: 100%;
+}
+
+.site-header .brand {
+  font-weight: 600;
+  color: var(--header-fg);
+  text-decoration: none;
+}
+
+
+.site-header a:focus-visible,
+.site-rail a:focus-visible,
+.site-rail button:focus-visible {
+  outline: 2px solid var(--header-focus);
+  outline-offset: 2px;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 // app/layout.tsx
 import "./globals.css";
 import type { Metadata } from "next";
+import SiteHeader from "@/components/SiteHeader";
 
 export const metadata: Metadata = {
   title: {
@@ -19,14 +20,10 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en">
       <body>
-        <header className="header">
-          <div className="container">tullyelly</div>
-        </header>
-
+        <SiteHeader />
         <main id="content" className="container" tabIndex={-1}>
           {children}
         </main>
-
         <footer className="footer">
           <div className="container">
             <small className="muted">© {new Date().getFullYear()} tullyelly</small>

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -1,4 +1,7 @@
+"use client";
+
 import Image from 'next/image';
+import { useEffect } from 'react';
 
 interface HeroProps {
   src: string;
@@ -11,6 +14,12 @@ interface HeroProps {
 
 export default function Hero({ src, alt, width, height, caption, priority = true }: HeroProps) {
   const normalizedSrc = src.startsWith('/') ? src : `/${src}`;
+  useEffect(() => {
+    document.body.classList.add('has-hero');
+    return () => {
+      document.body.classList.remove('has-hero');
+    };
+  }, []);
   return (
     <figure>
       <Image

--- a/components/SiteHeader.tsx
+++ b/components/SiteHeader.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+/**
+ * Global site header.
+ * - Applies across all routes via app/layout.tsx.
+ * - Uses global tokens (--blue-header, --header-fg, etc.).
+ * - Announcement rail component exists but is hidden by default until activated.
+ * - Pages that include `.has-hero` start transparent and solidify on scroll.
+ */
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+
+export default function SiteHeader() {
+  const [solid, setSolid] = useState(true);
+
+  useEffect(() => {
+    const hasHero =
+      document.body.classList.contains("has-hero") ||
+      document.querySelector("main")?.classList.contains("has-hero");
+    if (hasHero) {
+      setSolid(false);
+      const onScroll = () => {
+        setSolid(window.scrollY > 80);
+      };
+      window.addEventListener("scroll", onScroll);
+      return () => window.removeEventListener("scroll", onScroll);
+    }
+  }, []);
+
+  return (
+    <header className={`site-header ${solid ? "solid" : "transparent"}`}>
+      <div className="container header-inner">
+        <Link href="/" className="brand">
+          tullyelly
+        </Link>
+      </div>
+    </header>
+  );
+}

--- a/components/SiteRail.tsx
+++ b/components/SiteRail.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+interface SiteRailProps {
+  message?: string;
+}
+
+export default function SiteRail({ message }: SiteRailProps) {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    if (!message) return;
+    const dismissed = window.localStorage.getItem("site-rail-dismissed");
+    if (!dismissed) {
+      setVisible(true);
+    }
+  }, [message]);
+
+  const dismiss = () => {
+    window.localStorage.setItem("site-rail-dismissed", "1");
+    setVisible(false);
+  };
+
+  if (!message) {
+    return <div className="site-rail" style={{ display: "none" }} />;
+  }
+
+  if (!visible) return null;
+
+  return (
+    <div className="site-rail" role="region" aria-label="Site announcement">
+      <div className="container rail-inner">
+        <p className="rail-message">{message}</p>
+        <button className="rail-close" onClick={dismiss} aria-label="Dismiss announcement">
+          ×
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add site-wide announcement rail infrastructure (disabled by default)
- implement sticky header showing only the "tullyelly" brand
- clean up global styles for simplified header

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a62b3dec48832e8d962517455ac9d8