### PR TITLE
feat: configure fonts and add typography demo

### DIFF
--- a/__tests__/typography-demo.test.tsx
+++ b/__tests__/typography-demo.test.tsx
@@ -3,12 +3,17 @@ import TypographyDemo from "@/app/typography-demo/page";
 import "@testing-library/jest-dom";
 
 describe("Typography Demo page", () => {
-  it("renders heading hierarchy and code sample", () => {
+  it("renders heading hierarchy, meta, and code samples", () => {
     render(<TypographyDemo />);
     expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent("Typography");
     expect(screen.getByRole("heading", { level: 2 })).toHaveTextContent("Heading 2");
     expect(screen.getByRole("heading", { level: 3 })).toHaveTextContent("Heading 3");
-    const code = screen.getByText(/JetBrains Mono/, { selector: "code" });
-    expect(code.tagName).toBe("CODE");
+    expect(screen.getByRole("heading", { level: 4 })).toHaveTextContent("Heading 4");
+    const meta = screen.getByText(/Updated/);
+    expect(meta).toHaveClass("font-mono");
+    const codeInline = screen.getByText(/JetBrains Mono/, { selector: "code" });
+    expect(codeInline).toHaveClass("font-mono");
+    const block = screen.getByText(/function hello/).closest("pre");
+    expect(block).toHaveClass("font-mono");
   });
 });

--- a/__tests__/typography-demo.test.tsx
+++ b/__tests__/typography-demo.test.tsx
@@ -1,0 +1,14 @@
+import { render, screen } from "@testing-library/react";
+import TypographyDemo from "@/app/typography-demo/page";
+import "@testing-library/jest-dom";
+
+describe("Typography Demo page", () => {
+  it("renders heading hierarchy and code sample", () => {
+    render(<TypographyDemo />);
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent("Typography");
+    expect(screen.getByRole("heading", { level: 2 })).toHaveTextContent("Heading 2");
+    expect(screen.getByRole("heading", { level: 3 })).toHaveTextContent("Heading 3");
+    const code = screen.getByText(/JetBrains Mono/, { selector: "code" });
+    expect(code.tagName).toBe("CODE");
+  });
+});

--- a/app/fonts.ts
+++ b/app/fonts.ts
@@ -1,0 +1,13 @@
+import { Inter, JetBrains_Mono } from "next/font/google";
+
+export const inter = Inter({
+  subsets: ["latin"],
+  variable: "--font-inter",
+  display: "swap",
+});
+
+export const jetbrainsMono = JetBrains_Mono({
+  subsets: ["latin"],
+  variable: "--font-jetbrains-mono",
+  display: "swap",
+});

--- a/app/fonts.ts
+++ b/app/fonts.ts
@@ -1,13 +1,17 @@
 import { Inter, JetBrains_Mono } from "next/font/google";
 
+// Axis control: customize `weight`, `style`, or other supported axes as needed.
 export const inter = Inter({
   subsets: ["latin"],
-  variable: "--font-inter",
   display: "swap",
+  variable: "--font-inter",
+  // weight: ["400", "700"], // example axis control
 });
 
-export const jetbrainsMono = JetBrains_Mono({
+// JetBrains Mono also supports axis customization like `weight`.
+export const jbMono = JetBrains_Mono({
   subsets: ["latin"],
-  variable: "--font-jetbrains-mono",
   display: "swap",
+  variable: "--font-jbmono",
+  // weight: ["400", "700"], // example axis control
 });

--- a/app/globals.css
+++ b/app/globals.css
@@ -7,6 +7,9 @@
  */
 
 :root {
+  --font-inter: system-ui, sans-serif;
+  --font-jbmono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+
   /* Brand bases */
   --cream: #EEE1C6;            /* Cream City Cream */
   --blue: #0077C0;             /* Great Lakes Blue */

--- a/app/globals.css
+++ b/app/globals.css
@@ -65,7 +65,7 @@ code,
 pre,
 kbd,
 samp {
-  font-family: var(--font-jetbrains-mono);
+  font-family: var(--font-jbmono);
 }
 
 a {

--- a/app/globals.css
+++ b/app/globals.css
@@ -45,12 +45,6 @@
   --btn-secondary-bg: var(--green);
   --btn-secondary-fg: var(--text-on-green);
 
-  /* Fonts */
-  --font-sans: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto,
-    Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji";
-  --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
-    "Liberation Mono", "Courier New", monospace;
-
   /* Layout scale */
   --container: 72rem;
 }
@@ -63,8 +57,15 @@ body {
   margin: 0;
   background: var(--surface-page);
   color: var(--text-primary);
-  font-family: var(--font-sans);
+  font-family: var(--font-inter);
   line-height: 1.6;
+}
+
+code,
+pre,
+kbd,
+samp {
+  font-family: var(--font-jetbrains-mono);
 }
 
 a {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,7 +3,7 @@ import "./globals.css";
 import type { Metadata } from "next";
 import SiteHeader from "@/components/SiteHeader";
 import Footer from "@/components/Footer";
-import { inter, jetbrainsMono } from "./fonts";
+import { inter, jbMono } from "./fonts";
 
 export const metadata: Metadata = {
   title: {
@@ -20,7 +20,7 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en" className={`${inter.variable} ${jetbrainsMono.variable}`}>
+    <html lang="en" className={`${inter.variable} ${jbMono.variable}`}>
       <body className="min-h-screen flex flex-col bg-background text-foreground">
         <header>
           <SiteHeader />

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -21,7 +21,7 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" className={`${inter.variable} ${jbMono.variable}`}>
-      <body className="min-h-screen flex flex-col bg-background text-foreground">
+      <body className="font-sans min-h-screen flex flex-col bg-background text-foreground">
         <header>
           <SiteHeader />
         </header>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import "./globals.css";
 import type { Metadata } from "next";
 import SiteHeader from "@/components/SiteHeader";
 import Footer from "@/components/Footer";
+import { inter, jetbrainsMono } from "./fonts";
 
 export const metadata: Metadata = {
   title: {
@@ -19,7 +20,7 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en">
+    <html lang="en" className={`${inter.variable} ${jetbrainsMono.variable}`}>
       <body className="min-h-screen flex flex-col bg-background text-foreground">
         <header>
           <SiteHeader />

--- a/app/typography-demo/page.tsx
+++ b/app/typography-demo/page.tsx
@@ -7,14 +7,18 @@ export const metadata: Metadata = {
 export default function TypographyDemo() {
   return (
     <div className="space-y-6">
-      <h1>Typography</h1>
-      <p>Primary type uses Inter. Monospace uses JetBrains Mono.</p>
-      <h2>Heading 2</h2>
-      <p>Body copy demonstrates default sans-serif family.</p>
-      <h3>Heading 3</h3>
+      <h1 className="text-4xl font-extrabold">Typography</h1>
+      <p className="font-normal">Primary type uses Inter. Monospace uses JetBrains Mono.</p>
+      <h2 className="text-3xl font-bold">Heading 2</h2>
+      <p className="font-medium">Body copy demonstrates default sans-serif family.</p>
+      <h3 className="text-2xl font-semibold">Heading 3</h3>
+      <p className="font-normal">Another paragraph with regular weight.</p>
+      <h4 className="text-xl font-semibold">Heading 4</h4>
+      <p className="font-normal">Yet another body example.</p>
+      <p className="font-mono text-sm text-muted">Updated 2024-06-07</p>
       <p>
-        Inline code like <code className="font-mono">{`const font = 'JetBrains Mono';`}</code> uses
-        the monospace stack.
+        Inline code like <code className="font-mono">{`const font = 'JetBrains Mono';`}</code> uses the
+        monospace stack.
       </p>
       <pre className="font-mono p-4 rounded border border-border-subtle">
         <code>{`function hello() {\n  console.log('world');\n}`}</code>

--- a/app/typography-demo/page.tsx
+++ b/app/typography-demo/page.tsx
@@ -1,0 +1,24 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Typography Demo",
+};
+
+export default function TypographyDemo() {
+  return (
+    <div className="space-y-6">
+      <h1>Typography</h1>
+      <p>Primary type uses Inter. Monospace uses JetBrains Mono.</p>
+      <h2>Heading 2</h2>
+      <p>Body copy demonstrates default sans-serif family.</p>
+      <h3>Heading 3</h3>
+      <p>
+        Inline code like <code className="font-mono">{`const font = 'JetBrains Mono';`}</code> uses
+        the monospace stack.
+      </p>
+      <pre className="font-mono p-4 rounded border border-border-subtle">
+        <code>{`function hello() {\n  console.log('world');\n}`}</code>
+      </pre>
+    </div>
+  );
+}

--- a/docs/typography.md
+++ b/docs/typography.md
@@ -7,13 +7,13 @@ This site self-hosts [Inter](https://fonts.google.com/specimen/Inter) as the pri
 Fonts are defined in `app/fonts.ts` using `next/font/google` with CSS variables:
 
 ```ts
-import { inter, jetbrainsMono } from "@/app/fonts";
+import { inter, jbMono } from "@/app/fonts";
 ```
 
 The variables are attached to the `<html>` element in `app/layout.tsx`:
 
 ```tsx
-<html lang="en" className={`${inter.variable} ${jetbrainsMono.variable}`}>
+<html lang="en" className={`${inter.variable} ${jbMono.variable}`}>
 ```
 
 Tailwind exposes them as `font-sans` and `font-mono` utilities.

--- a/docs/typography.md
+++ b/docs/typography.md
@@ -1,0 +1,23 @@
+# Typography
+
+This site self-hosts [Inter](https://fonts.google.com/specimen/Inter) as the primary sans-serif face and [JetBrains Mono](https://fonts.google.com/specimen/JetBrains+Mono) for monospace accents.
+
+## Usage
+
+Fonts are defined in `app/fonts.ts` using `next/font/google` with CSS variables:
+
+```ts
+import { inter, jetbrainsMono } from "@/app/fonts";
+```
+
+The variables are attached to the `<html>` element in `app/layout.tsx`:
+
+```tsx
+<html lang="en" className={`${inter.variable} ${jetbrainsMono.variable}`}>
+```
+
+Tailwind exposes them as `font-sans` and `font-mono` utilities.
+
+## Demo
+
+Visit `/typography-demo` to see the hierarchy and monospace usage.

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -31,8 +31,24 @@ export default {
         container: "var(--container)"
       },
       fontFamily: {
-        sans: ["var(--font-inter)"],
-        mono: ["var(--font-jbmono)"]
+        sans: [
+          "var(--font-inter)",
+          "system-ui",
+          "-apple-system",
+          "Segoe UI",
+          "Roboto",
+          "Helvetica",
+          "Arial",
+          "sans-serif"
+        ],
+        mono: [
+          "var(--font-jbmono)",
+          "ui-monospace",
+          "SFMono-Regular",
+          "Menlo",
+          "Consolas",
+          "monospace"
+        ]
       }
     }
   },

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -31,8 +31,8 @@ export default {
         container: "var(--container)"
       },
       fontFamily: {
-        sans: ["var(--font-sans)"],
-        mono: ["var(--font-mono)"]
+        sans: ["var(--font-inter)"],
+        mono: ["var(--font-jetbrains-mono)"]
       }
     }
   },

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -32,7 +32,7 @@ export default {
       },
       fontFamily: {
         sans: ["var(--font-inter)"],
-        mono: ["var(--font-jetbrains-mono)"]
+        mono: ["var(--font-jbmono)"]
       }
     }
   },


### PR DESCRIPTION
## Summary
- self-host Inter and JetBrains Mono with next/font
- extend Tailwind and globals for new font stacks
- add typography demo page, test, and docs

## Testing
- `npm test` *(fails: Footer a11y tests cannot find navigation and email field)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a6a5cc76cc832eac5d991d4568ca41