### PR TITLE
test: verify typography setup

### DIFF
--- a/app/__tests__/typography.test.tsx
+++ b/app/__tests__/typography.test.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+jest.mock("next/font/local", () => {
+  return (opts: any) => ({
+    variable: opts.variable,
+    className: opts.variable,
+  });
+});
+
+import RootLayout from "../layout"; // default export
+// Note: RootLayout applies `${inter.variable} ${jbMono.variable}` to <html>
+
+function Page() {
+  return (
+    <main>
+      <h1>Typography Check</h1>
+      <code className="font-mono">const x = 1;</code>
+    </main>
+  );
+}
+
+describe("Typography system", () => {
+  it("applies Inter and JB Mono variables to <html>", () => {
+    // Render the layout with a child page
+    render(
+      // @ts-expect-error – RootLayout’s signature matches Next’s layout contract
+      <RootLayout>
+        <Page />
+      </RootLayout>
+    );
+
+    const html = document.documentElement; // <html>
+    const className = html.className;
+
+    // We don’t import inter/jbMono here to avoid coupling the test to implementation details.
+    // We only assert that two non-empty variable-bearing classes were applied.
+    expect(className).toMatch(/--font-inter/);
+    expect(className).toMatch(/--font-jbmono/);
+  });
+
+  it("exposes a usable monospace utility via Tailwind (font-mono)", () => {
+    render(
+      // @ts-expect-error – see note above
+      <RootLayout>
+        <Page />
+      </RootLayout>
+    );
+
+    const code = screen.getByText(/const x = 1;/i);
+    expect(code).toHaveClass("font-mono");
+  });
+});

--- a/app/__tests__/typography.test.tsx
+++ b/app/__tests__/typography.test.tsx
@@ -1,15 +1,8 @@
+// app/__tests__/typography.test.tsx
 import React from "react";
 import { render, screen } from "@testing-library/react";
-
-jest.mock("next/font/local", () => {
-  return (opts: any) => ({
-    variable: opts.variable,
-    className: opts.variable,
-  });
-});
-
-import RootLayout from "../layout"; // default export
-// Note: RootLayout applies `${inter.variable} ${jbMono.variable}` to <html>
+import "@testing-library/jest-dom";
+import RootLayout from "../layout";
 
 function Page() {
   return (
@@ -22,9 +15,7 @@ function Page() {
 
 describe("Typography system", () => {
   it("applies Inter and JB Mono variables to <html>", () => {
-    // Render the layout with a child page
     render(
-      // @ts-expect-error – RootLayout’s signature matches Next’s layout contract
       <RootLayout>
         <Page />
       </RootLayout>
@@ -33,15 +24,13 @@ describe("Typography system", () => {
     const html = document.documentElement; // <html>
     const className = html.className;
 
-    // We don’t import inter/jbMono here to avoid coupling the test to implementation details.
-    // We only assert that two non-empty variable-bearing classes were applied.
+    // Assert variable tokens are present (don’t couple to hashed classnames)
     expect(className).toMatch(/--font-inter/);
     expect(className).toMatch(/--font-jbmono/);
   });
 
   it("exposes a usable monospace utility via Tailwind (font-mono)", () => {
     render(
-      // @ts-expect-error – see note above
       <RootLayout>
         <Page />
       </RootLayout>

--- a/docs/typography.md
+++ b/docs/typography.md
@@ -1,43 +1,35 @@
 # Typography
 
-This site self-hosts [Inter](https://fonts.google.com/specimen/Inter) as the primary sans-serif face and [JetBrains Mono](https://fonts.google.com/specimen/JetBrains+Mono) for monospace accents.
+This site uses **Inter** for proportional sans (body/headings) and **JetBrains Mono** for monospace accents (code/meta). Fonts are self-hosted and applied via `next/font` with CSS variables.
 
 ## Usage
 
-Fonts are defined in `app/fonts.ts` using `next/font/google` with CSS variables:
+- Defined in `app/fonts.ts` and attached in `app/layout.tsx`:
+  ```tsx
+  <html lang="en" className={`${inter.variable} ${jbMono.variable}`}>
+    <body className="font-sans">{/* … */}</body>
+  </html>
+  ```
 
-```ts
-import { inter, jbMono } from "@/app/fonts";
-```
+- Tailwind utilities:
 
-The variables are attached to the `<html>` element in `app/layout.tsx`:
+  - `font-sans` → Inter stack
+  - `font-mono` → JetBrains Mono stack
 
-```tsx
-<html lang="en" className={`${inter.variable} ${jbMono.variable}`}>
-```
+## Where to tweak
 
-Tailwind exposes them as `font-sans` and `font-mono` utilities.
+- **Weights / axes**: adjust in `app/fonts.ts` (variable font ranges).
+- **Default body font**: `app/layout.tsx` (`className="font-sans"` on `<body>`).
+- **Code snippets**: apply `className="font-mono"` or global CSS for `code, pre, kbd, samp`.
 
-## Variable axes
+## Performance notes
 
-Both imports load variable fonts. Inter exposes `wght` (weight) by default and adds `opsz` (optical size) via the `axes` option. JetBrains Mono provides the `wght` axis:
+- Fonts are self-hosted WOFF2; `display: "swap"` minimizes CLS.
+- Verify no external font hosts in DevTools → Network (should serve from same origin).
 
-```ts
-import { Inter, JetBrains_Mono } from "next/font/google";
+## Quick checks
 
-export const inter = Inter({
-  subsets: ["latin"],
-  display: "swap",
-  variable: "--font-inter",
-  axes: ["opsz"], // `wght` is implicit
-});
+- Build: `npm run build`
+- Test: `npm test`
+- Lighthouse (optional): run against `/typography-demo`; CLS should be ≤ 0.01
 
-export const jbMono = JetBrains_Mono({
-  subsets: ["latin"],
-  display: "swap",
-  variable: "--font-jbmono",
-});
-
-## Demo
-
-Visit `/typography-demo` to see the hierarchy and monospace usage.


### PR DESCRIPTION
## Summary
- add Jest test to confirm Inter and JetBrains Mono font variables attach to `<html>` and `font-mono` utility works
- document typography setup, tweaks, and performance notes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7db97ec4c832eb391f44d48df3f29