### PR TITLE
style: ensure footer links are white

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -7,12 +7,16 @@ export default function Footer() {
   return (
     <footer
       role="contentinfo"
-      className="w-full text-center text-sm"
-      style={{ backgroundColor: "var(--brand-chrome)", color: "var(--brand-chrome-fg)" }}
+      className={[
+        "w-full text-center text-sm",
+        "bg-blue text-text-on-blue",
+        "[&_a]:text-text-on-blue [&_a:visited]:text-text-on-blue [&_a:hover]:text-text-on-blue [&_a:focus]:text-text-on-blue",
+        "[&_a]:no-underline [&_a:hover]:underline [&_a:focus]:underline [&_a]:underline-offset-4",
+      ].join(" ")}
     >
       <div className="mx-auto max-w-7xl px-6 py-6">
         © {new Date().getFullYear()}{" "}
-        <Link href="/" className="underline">
+        <Link href="/" className="font-semibold">
           tullyelly
         </Link>
         . All rights reserved.


### PR DESCRIPTION
## Summary
- style footer links white on blue background with Tailwind

## Testing
- `npm test` *(fails: Typography system – applies Inter and JB Mono variables to <html>; header and footer share the same background)*

------
https://chatgpt.com/codex/tasks/task_e_68a7e2db3dd8832e992466f1f90c1622