### PR TITLE
synced branding on header and footer [WU-194]

### DIFF
--- a/components/BrandedLink.tsx
+++ b/components/BrandedLink.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import Link, { LinkProps } from "next/link";
+import { ComponentPropsWithoutRef } from "react";
+
+type Props = LinkProps & ComponentPropsWithoutRef<"a"> & {
+  className?: string;
+};
+
+// simple class combiner
+function cn(...xs: Array<string | false | undefined>) {
+  return xs.filter(Boolean).join(" ");
+}
+
+export default function BrandedLink({ className, ...props }: Props) {
+  return (
+    <Link
+      {...props}
+      className={cn(
+        // force white across states to avoid default blue links
+        "text-white visited:text-white hover:text-white focus:text-white",
+        // underline behavior + readability
+        "no-underline hover:underline underline-offset-4",
+        // weight + tracking to match header
+        "font-semibold tracking-tight",
+        // accessible focus ring that works on brand chrome
+        "focus:outline-none focus-visible:ring-2 focus-visible:ring-white/70",
+        "focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--brand-chrome)]",
+        className
+      )}
+      // keep using your CSS var for foreground color (white on blue)
+      style={{ color: "var(--brand-chrome-fg)", ...(props.style || {}) }}
+    />
+  );
+}

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,7 +1,6 @@
-// components/Footer.tsx
 "use client";
 
-import Link from "next/link";
+import BrandedLink from "@/components/BrandedLink";
 
 export default function Footer() {
   return (
@@ -12,9 +11,7 @@ export default function Footer() {
     >
       <div className="mx-auto max-w-7xl px-6 py-6">
         © {new Date().getFullYear()}{" "}
-        <Link href="/" className="underline">
-          tullyelly
-        </Link>
+        <BrandedLink href="/">tullyelly</BrandedLink>
         . All rights reserved.
       </div>
     </footer>

--- a/components/SiteHeader.tsx
+++ b/components/SiteHeader.tsx
@@ -1,28 +1,17 @@
 "use client";
 
-import Link from "next/link";
+import BrandedLink from "@/components/BrandedLink";
 
 export default function SiteHeader() {
   return (
     <header
-      className="w-full text-white"
+      className="w-full"
       style={{ backgroundColor: "var(--brand-chrome)", color: "var(--brand-chrome-fg)" }}
     >
       <div className="mx-auto max-w-7xl px-6 py-4">
-        <Link
-          href="/"
-          aria-label="tullyelly — home"
-          className={[
-            "text-white visited:text-white hover:text-white focus:text-white",
-            "no-underline hover:underline underline-offset-4",
-            "font-semibold tracking-tight",
-            "focus:outline-none focus-visible:ring-2 focus-visible:ring-white/70",
-            "focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--brand-chrome)]",
-          ].join(" ")}
-          style={{ color: "var(--brand-chrome-fg)" }}
-        >
+        <BrandedLink href="/" aria-label="tullyelly — home">
           tullyelly
-        </Link>
+        </BrandedLink>
       </div>
     </header>
   );


### PR DESCRIPTION
## Summary
Explain what this PR changes and why.

## Jira
WU-XXX

## Reviewers
- @tullyelly

## Checks
- [ ] Lint passes locally (`npm run lint`)
- [ ] Typecheck passes locally (`npm run typecheck`) *(if present)*
- [ ] Builds locally (`npm run build`)
- [ ] Docs updated if needed

## Screenshots (if UI)
