### PR TITLE
feat: add typography nav link

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ This repo is already structured for one-click deploys.
 
 ## ✅ Quick Notes
 
-* Static pages: `app/roadwork-rappin`, `app/heels-have-eyes`, `app/ui-lab`
+* Static pages: `app/roadwork-rappin`, `app/heels-have-eyes`, `app/ui-lab`, `app/typography-demo`
 * `globals.css`: design tokens + Tailwind entry point
 * `tailwind.config.mjs`: maps tokens → Tailwind theme
 * Set `NEXT_PUBLIC_ANNOUNCEMENT` to display the top banner

--- a/__tests__/site-header-nav.test.tsx
+++ b/__tests__/site-header-nav.test.tsx
@@ -1,0 +1,11 @@
+import { render, screen } from "@testing-library/react";
+import SiteHeader from "@/components/SiteHeader";
+import "@testing-library/jest-dom";
+
+describe("SiteHeader navigation", () => {
+  it("includes Typography demo link", () => {
+    render(<SiteHeader />);
+    const typographyLink = screen.getByRole("link", { name: "Typography" });
+    expect(typographyLink).toHaveAttribute("href", "/typography-demo");
+  });
+});

--- a/components/SiteHeader.tsx
+++ b/components/SiteHeader.tsx
@@ -12,8 +12,9 @@ export default function SiteHeader() {
         <BrandedLink href="/" aria-label="tullyelly — home">
           tullyelly
         </BrandedLink>
-        <nav>
+        <nav className="flex items-center gap-6">
           <BrandedLink href="/ui-lab">UI Lab</BrandedLink>
+          <BrandedLink href="/typography-demo">Typography</BrandedLink>
         </nav>
       </div>
     </header>


### PR DESCRIPTION
## Summary
- add Typography demo nav link in header
- document Typography static page in README
- add test verifying header link

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a820e9d828832e8e9cf98bd8f51ff6