### PR TITLE
feat: add db pool helper and env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+DATABASE_URL=postgresql://username:password@neon-prod-host/dbname?sslmode=require
+PREVIEW_DATABASE_URL=postgresql://username:password@neon-preview-host/dbname?sslmode=require
+TEST_DATABASE_URL=postgresql://username:password@neon-test-host/dbname?sslmode=require

--- a/app/lib/db.ts
+++ b/app/lib/db.ts
@@ -1,0 +1,54 @@
+import 'server-only';
+
+import { Pool } from 'pg';
+
+let pool: Pool | undefined;
+
+function redact(url: string) {
+  return url.replace(/:[^:@]*@/, ':***@');
+}
+
+function assertDbSafety(url: string) {
+  const prodHost = /neon-prod-host/i;
+  const devHost = /neon-dev-host/i;
+  const isProd = process.env.NODE_ENV === 'production';
+
+  if (isProd && devHost.test(url)) {
+    throw new Error('Refusing to use dev database in production runtime');
+  }
+
+  if (!isProd && prodHost.test(url)) {
+    throw new Error('Refusing to use prod database outside production runtime');
+  }
+}
+
+export function getPool(): Pool {
+  if (pool) return pool;
+
+  const connectionString = process.env.DATABASE_URL;
+  if (!connectionString) {
+    throw new Error('DATABASE_URL is not defined');
+  }
+
+  assertDbSafety(connectionString);
+
+  const max = process.env.NODE_ENV === 'production' ? 10 : 5;
+  const newPool = new Pool({ connectionString, ssl: { rejectUnauthorized: false }, max });
+
+  newPool.on('error', (err) => {
+    console.error('database connection error', {
+      message: err.message,
+      database: redact(connectionString),
+    });
+  });
+
+  pool = newPool;
+  return pool;
+}
+
+export async function query<T>(text: string, params: any[] = []): Promise<{ rows: T[] }> {
+  const result = await getPool().query<T>(text, params);
+  return { rows: result.rows };
+}
+
+export { assertDbSafety };


### PR DESCRIPTION
## Summary
- add .env example for database URLs
- add singleton PostgreSQL pool helper with safety checks

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68acec23afac832ebd0a0c48a17458d3