### PR TITLE
refactor release details toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,24 @@ See [docs/authoring.md](docs/authoring.md) for the quickest way to scaffold and 
 
 ## 🗃️ Database
 
-This project requires a **Postgres** database. Set the `DATABASE_URL` environment variable to point to your instance.
+This project requires a **Postgres** database. Use explicit environment variables for each runtime:
+
+- `DATABASE_URL` – production
+- `PREVIEW_DATABASE_URL` – Vercel preview
+- `TEST_DATABASE_URL` – local development and tests
+
+For tests, create a `.env.test` file so `npm test` can load a dedicated database URL:
+
+```bash
+# .env.test
+TEST_DATABASE_URL=postgresql://user:pass@localhost:5432/tullyelly_test
+```
+
+Using a Neon branch instead of local Postgres? Point `TEST_DATABASE_URL` at the branch URL:
+
+```bash
+TEST_DATABASE_URL=postgresql://…@ep-round-forest-aeuxacm9.c-2.us-east-2.aws.neon.tech/tullyelly_db?sslmode=require&channel_binding=require
+```
 
 After configuring the database, run:
 
@@ -87,6 +104,17 @@ Apply release helper functions:
 
 ```bash
 psql $NEON_DATABASE_URL -f db/migrations/002_fn_next_release_functions.sql
+```
+
+Verify connectivity:
+
+```bash
+curl -s http://localhost:3000/api/_health
+curl -s http://localhost:3000/api/releases
+curl -s -X POST -H 'Content-Type: application/json' \
+  -d '{"label":"Test patch"}' http://localhost:3000/api/releases/patch # mutates data
+curl -s -X POST -H 'Content-Type: application/json' \
+  -d '{"label":"Test minor"}' http://localhost:3000/api/releases/minor # mutates data
 ```
 
 ---

--- a/__tests__/db.smoke.test.ts
+++ b/__tests__/db.smoke.test.ts
@@ -1,4 +1,4 @@
-import { query, endPool } from '@/app/lib/db';
+import { query } from '@/app/lib/db';
 
 describe('database smoke test', () => {
   it('SELECT 1 returns 1', async () => {
@@ -11,9 +11,5 @@ describe('database smoke test', () => {
     // Not asserting exact name; just ensure we got *something* in test env
     expect(typeof rows[0].current_database).toBe('string');
     expect(rows[0].current_database.length).toBeGreaterThan(0);
-  });
-
-  afterAll(async () => {
-    await endPool();
   });
 });

--- a/app/api/_health/route.ts
+++ b/app/api/_health/route.ts
@@ -1,0 +1,11 @@
+import { query } from '@/app/lib/db';
+
+// curl -s http://localhost:3000/api/_health
+
+type NowRow = { now: string };
+
+export async function GET() {
+  const { rows } = await query<NowRow>('SELECT now() AS now');
+  const now = rows[0]?.now;
+  return Response.json({ now });
+}

--- a/app/api/releases/[id]/route.ts
+++ b/app/api/releases/[id]/route.ts
@@ -1,0 +1,56 @@
+import type { NextRequest } from 'next/server';
+import { query } from '@/app/lib/db';
+
+type RouteContext<Path extends string> = { params: Promise<Record<string, string>> };
+
+// curl -s http://localhost:3000/api/releases/1
+
+export interface ReleaseRow {
+  id: number;
+  release_name: string;
+  semver: string;
+  major: number;
+  minor: number;
+  patch: number;
+  year: number;
+  month: number;
+  label: string | null;
+  status: string;
+  release_type: string;
+  created_at: string;
+  created_by: string | null;
+  updated_at: string | null;
+  updated_by: string | null;
+}
+
+export async function GET(
+  _req: NextRequest,
+  { params }: RouteContext<'/api/releases/[id]'>
+) {
+  const { id } = await params;
+  const numId = Number.parseInt(id, 10);
+  if (!Number.isInteger(numId)) {
+    return Response.json({ error: 'invalid id' }, { status: 400 });
+  }
+
+  const sql = `
+  SELECT id, release_name, semver,
+         major, minor, patch, year, month, label,
+         status, release_type,
+         created_at, created_by, updated_at, updated_by
+  FROM dojo.v_shaolin_scrolls
+  WHERE id = $1;`;
+
+  try {
+    const { rows } = await query<ReleaseRow>(sql, [numId]);
+    const row = rows[0];
+    if (!row) {
+      return Response.json({ error: 'not found' }, { status: 404 });
+    }
+    return Response.json(row);
+  } catch (err) {
+    console.error('releases id query failed:', err);
+    return Response.json({ error: 'database error' }, { status: 500 });
+  }
+}
+

--- a/app/api/releases/minor/route.ts
+++ b/app/api/releases/minor/route.ts
@@ -1,0 +1,39 @@
+import { query } from '@/app/lib/db';
+
+// curl -s -X POST -H 'Content-Type: application/json' \
+//   -d '{"label":"First minor"}' http://localhost:3000/api/releases/minor
+
+interface DbRow {
+  scroll_id: number;
+  generated_name: string;
+}
+
+export type Row = {
+  id: string;
+  generated_name: string;
+};
+
+export async function POST(req: Request) {
+  let label: string;
+  try {
+    const body = await req.json();
+    label = typeof body.label === 'string' ? body.label.trim() : '';
+  } catch {
+    return Response.json({ error: 'invalid body' }, { status: 400 });
+  }
+
+  if (!label || label.length > 120) {
+    return Response.json({ error: 'invalid label' }, { status: 400 });
+  }
+
+  const sql = 'SELECT * FROM dojo.fn_next_minor($1::text);';
+  try {
+    const { rows } = await query<DbRow>(sql, [label]);
+    const row = rows[0];
+    const item: Row = { id: String(row.scroll_id), generated_name: row.generated_name };
+    return Response.json(item);
+  } catch (err) {
+    console.error('fn_next_minor failed:', err);
+    return Response.json({ error: 'database error' }, { status: 500 });
+  }
+}

--- a/app/api/releases/patch/route.ts
+++ b/app/api/releases/patch/route.ts
@@ -1,0 +1,39 @@
+import { query } from '@/app/lib/db';
+
+// curl -s -X POST -H 'Content-Type: application/json' \
+//   -d '{"label":"First hotfix"}' http://localhost:3000/api/releases/patch
+
+interface DbRow {
+  scroll_id: number;
+  generated_name: string;
+}
+
+export type Row = {
+  id: string;
+  generated_name: string;
+};
+
+export async function POST(req: Request) {
+  let label: string;
+  try {
+    const body = await req.json();
+    label = typeof body.label === 'string' ? body.label.trim() : '';
+  } catch {
+    return Response.json({ error: 'invalid body' }, { status: 400 });
+  }
+
+  if (!label || label.length > 120) {
+    return Response.json({ error: 'invalid label' }, { status: 400 });
+  }
+
+  const sql = 'SELECT * FROM dojo.fn_next_patch($1::text);';
+  try {
+    const { rows } = await query<DbRow>(sql, [label]);
+    const row = rows[0];
+    const item: Row = { id: String(row.scroll_id), generated_name: row.generated_name };
+    return Response.json(item);
+  } catch (err) {
+    console.error('fn_next_patch failed:', err);
+    return Response.json({ error: 'database error' }, { status: 500 });
+  }
+}

--- a/app/api/releases/route.ts
+++ b/app/api/releases/route.ts
@@ -1,0 +1,59 @@
+import { query } from '@/app/lib/db';
+
+// curl -s 'http://localhost:3000/api/releases?limit=5'
+
+interface DbRow {
+  id: number;
+  release_name: string;
+  status: string;
+  release_type: string;
+  semver: string;
+}
+
+export type Row = {
+  id: string;
+  release_name: string;
+  status: string;
+  release_type: string;
+  semver: string;
+};
+
+export async function GET(req: Request) {
+  const url = new URL(req.url);
+  const limitParam = url.searchParams.get('limit');
+  const offsetParam = url.searchParams.get('offset');
+
+  let limit = Number.parseInt(limitParam ?? '20', 10);
+  let offset = Number.parseInt(offsetParam ?? '0', 10);
+
+  if (Number.isNaN(limit) || limit < 1) limit = 20;
+  if (Number.isNaN(offset) || offset < 0) offset = 0;
+  if (limit > 100) limit = 100;
+
+  const sql = `
+SELECT
+  id,
+  release_name,
+  status,
+  release_type,
+  semver
+FROM dojo.v_shaolin_scrolls
+ORDER BY created_at DESC
+LIMIT $1 OFFSET $2;
+`;
+
+  try {
+    const { rows } = await query<DbRow>(sql, [limit, offset]);
+    const items: Row[] = rows.map((r) => ({
+      id: String(r.id),
+      release_name: r.release_name,
+      status: r.status,
+      release_type: r.release_type,
+      semver: r.semver,
+    }));
+    return Response.json({ items, page: { limit, offset } });
+  } catch (err) {
+    console.error('releases query failed:', err);
+    return Response.json({ error: 'database error' }, { status: 500 });
+  }
+}

--- a/app/lib/db.ts
+++ b/app/lib/db.ts
@@ -1,76 +1,41 @@
 import 'server-only';
 import { Pool } from 'pg';
+import { getDatabaseUrl, getRuntimeEnv } from './env';
 
-let pool: Pool | null = null;
+let _pool: Pool | null = null;
 
-// Known Neon hosts (no secrets). Update if you ever rotate hosts.
-const PROD_HOST    = 'ep-jolly-flower-ae4bmy06.c-2.us-east-2.aws.neon.tech';
-const PREVIEW_HOST = 'ep-steep-frog-ae7rg845.c-2.us-east-2.aws.neon.tech';
-const TEST_HOST    = 'ep-round-forest-aeuxacm9.c-2.us-east-2.aws.neon.tech';
-
-function assertDbSafety(url: string) {
-  // Vercel sets VERCEL_ENV to 'production' | 'preview' | 'development'
-  const env = process.env.VERCEL_ENV ?? 'development';
-  const hostname = new URL(url).hostname;
-
-  const isProdHost    = hostname === PROD_HOST;
-  const isPreviewHost = hostname === PREVIEW_HOST;
-  const isTestHost    = hostname === TEST_HOST;
-
-  // --- Hard rules ---
-  if (env === 'production' && !isProdHost) {
-    throw new Error(
-      `Safety check failed: production runtime cannot use ${hostname}. Expected ${PROD_HOST}.`
-    );
+function assertDbSafety(dbUrl: string) {
+  const { vercelEnv, nodeEnv } = getRuntimeEnv();
+  const env = nodeEnv === 'test' ? 'development' : vercelEnv;
+  const host = new URL(dbUrl).hostname;
+  const allow: Record<'development' | 'preview' | 'production', string[]> = {
+    development: [
+      'ep-round-forest-aeuxacm9.c-2.us-east-2.aws.neon.tech',
+      'localhost',
+      '127.0.0.1',
+    ],
+    preview: ['ep-steep-frog-ae7rg845.c-2.us-east-2.aws.neon.tech'],
+    production: ['ep-jolly-flower-ae4bmy06.c-2.us-east-2.aws.neon.tech'],
+  };
+  if (!allow[env].includes(host)) {
+    throw new Error(`Safety check failed: ${env} runtime cannot use DB host "${host}".`);
   }
-
-  if (env === 'preview') {
-    if (isProdHost) {
-      throw new Error('Safety check failed: preview runtime cannot point at the production database.');
-    }
-    // Optionally enforce preview host strictly:
-    // if (!isPreviewHost) {
-    //   throw new Error(`Preview runtime expected ${PREVIEW_HOST}, got ${hostname}.`);
-    // }
-  }
-
-  if (env === 'development' && isProdHost) {
-    throw new Error('Safety check failed: development runtime cannot point at the production database.');
-  }
+  // swap any env var locally to verify the error above is thrown
 }
-
-// ...existing code above...
 
 export function getPool() {
-  if (pool) return pool;
-  const url = process.env.DATABASE_URL;
-  if (!url) throw new Error('DATABASE_URL is not defined');
-  assertDbSafety(url);
-  pool = new Pool({
-    connectionString: url,
-    ssl: { rejectUnauthorized: false },
-    max: process.env.VERCEL_ENV === 'production' ? 10 : 5,
-  });
-  return pool;
+  if (_pool) return _pool;
+  const dbUrl = getDatabaseUrl();
+  assertDbSafety(dbUrl);
+  const { vercelEnv, nodeEnv } = getRuntimeEnv();
+  const env = nodeEnv === 'test' ? 'development' : vercelEnv;
+  if (env !== 'production') {
+    console.debug('[env]', env, new URL(dbUrl).hostname);
+  }
+  _pool = new Pool({ connectionString: dbUrl, max: 5, idleTimeoutMillis: 30_000 });
+  return _pool;
 }
 
-export async function query<T = any>(text: string, params?: any[]) {
-  const client = await getPool().connect();
-  try {
-    const result = await client.query<T>(text, params);
-    return { rows: result.rows };
-  } catch (err: any) {
-    console.error('Database query error:', { message: err?.message ?? 'unknown error' });
-    throw err;
-  } finally {
-    client.release();
-  }
-}
-
-// ✅ added for test teardown and CI
-export async function endPool() {
-  if (pool) {
-    await pool.end();
-    pool = null;
-  }
+export function query<T>(text: string, params?: any[]) {
+  return getPool().query<T>(text, params);
 }

--- a/app/lib/env.ts
+++ b/app/lib/env.ts
@@ -1,0 +1,32 @@
+import 'server-only';
+
+type VercelEnv = 'production' | 'preview' | 'development';
+
+export function getRuntimeEnv() {
+  const vercelEnv = (process.env.VERCEL_ENV as VercelEnv | undefined) ?? 'development';
+  const nodeEnv = process.env.NODE_ENV ?? 'development';
+  const isVercel = Boolean(process.env.VERCEL);
+  return { vercelEnv, nodeEnv, isVercel };
+}
+
+function must(name: string) {
+  const value = process.env[name];
+  if (!value) throw new Error(`Missing env var: ${name}`);
+  return value;
+}
+
+export function getDatabaseUrl() {
+  const { vercelEnv, nodeEnv } = getRuntimeEnv();
+  if (nodeEnv === 'test') {
+    return must('TEST_DATABASE_URL');
+  }
+  switch (vercelEnv) {
+    case 'production':
+      return must('DATABASE_URL');
+    case 'preview':
+      return must('PREVIEW_DATABASE_URL');
+    case 'development':
+    default:
+      return must('TEST_DATABASE_URL');
+  }
+}

--- a/app/shaolin-scrolls/page.module.css
+++ b/app/shaolin-scrolls/page.module.css
@@ -1,0 +1,37 @@
+.container {
+  padding: 1rem;
+}
+
+.create {
+  margin-bottom: 1rem;
+}
+
+.create form {
+  display: inline-block;
+  margin-right: 1rem;
+}
+
+.create input {
+  margin-left: 0.25rem;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.table th,
+.table td {
+  border: 1px solid #ccc;
+  padding: 0.5rem;
+  text-align: left;
+}
+
+.details summary {
+  cursor: pointer;
+}
+
+.detail {
+  margin: 0.5rem 0;
+  white-space: pre-wrap;
+}

--- a/app/shaolin-scrolls/page.tsx
+++ b/app/shaolin-scrolls/page.tsx
@@ -1,0 +1,69 @@
+import CreateRelease from '@/components/CreateRelease';
+import ReleaseRowDetail from '@/components/ReleaseRowDetail';
+import styles from './page.module.css';
+
+interface ListItem {
+  id: number;
+  release_name: string;
+  status: string;
+  release_type: string;
+  created_at: string;
+}
+
+async function fetchJson<T>(path: string): Promise<T> {
+  const base = process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : 'http://localhost:3000';
+  const res = await fetch(`${base}${path}`, { cache: 'no-store' });
+  if (!res.ok) {
+    throw new Error(`fetch failed: ${path}`);
+  }
+  return res.json();
+}
+
+export default async function ShaolinScrollsPage() {
+  const list = await fetchJson<{ items: Array<{ id: number; release_name: string; status: string; release_type: string }> }>(
+    '/api/releases?limit=20'
+  );
+
+  const items: ListItem[] = await Promise.all(
+    list.items.map(async (item) => {
+      const detail = await fetchJson<{ created_at: string }>(`/api/releases/${item.id}`);
+      return { ...item, created_at: detail.created_at };
+    })
+  );
+
+  return (
+    <main className={styles.container}>
+      <h1>Shaolin Scrolls</h1>
+      <div className={styles.create}>
+        <CreateRelease />
+      </div>
+      <table className={styles.table}>
+        <thead>
+          <tr>
+            <th scope="col">Release Name</th>
+            <th scope="col">Status</th>
+            <th scope="col">Type</th>
+            <th scope="col">Created</th>
+            <th scope="col">Details</th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((item) => (
+            <tr key={item.id}>
+              <td>{item.release_name}</td>
+              <td>{item.status}</td>
+              <td>{item.release_type}</td>
+              <td>
+                <time dateTime={item.created_at}>{item.created_at}</time>
+              </td>
+              <td>
+                <ReleaseRowDetail id={item.id} />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </main>
+  );
+}
+

--- a/components/CreateRelease.tsx
+++ b/components/CreateRelease.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+export default function CreateRelease() {
+  const router = useRouter();
+  const [patchLabel, setPatchLabel] = useState('');
+  const [minorLabel, setMinorLabel] = useState('');
+  const [patchMsg, setPatchMsg] = useState('');
+  const [minorMsg, setMinorMsg] = useState('');
+
+  async function submit(
+    type: 'patch' | 'minor',
+    label: string,
+    setLabel: (v: string) => void,
+    setMsg: (v: string) => void
+  ) {
+    const trimmed = label.trim().slice(0, 120);
+    if (!trimmed) return;
+    try {
+      const res = await fetch(`/api/releases/${type}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ label: trimmed }),
+      });
+      if (res.ok) {
+        setLabel('');
+        setMsg('Created');
+        router.refresh();
+      }
+    } catch {
+      // ignore errors for now
+    }
+  }
+
+  return (
+    <div>
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          submit('patch', patchLabel, setPatchLabel, setPatchMsg);
+        }}
+      >
+        <label htmlFor="patch-label">Patch label</label>
+        <input
+          id="patch-label"
+          name="patch-label"
+          value={patchLabel}
+          maxLength={120}
+          onChange={(e) => setPatchLabel(e.target.value)}
+          required
+        />
+        <button type="submit">Create Patch</button>
+        {patchMsg && <small>{patchMsg}</small>}
+      </form>
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          submit('minor', minorLabel, setMinorLabel, setMinorMsg);
+        }}
+      >
+        <label htmlFor="minor-label">Minor label</label>
+        <input
+          id="minor-label"
+          name="minor-label"
+          value={minorLabel}
+          maxLength={120}
+          onChange={(e) => setMinorLabel(e.target.value)}
+          required
+        />
+        <button type="submit">Create Minor</button>
+        {minorMsg && <small>{minorMsg}</small>}
+      </form>
+    </div>
+  );
+}
+

--- a/components/ReleaseRowDetail.tsx
+++ b/components/ReleaseRowDetail.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+import { Fragment, useState } from 'react';
+
+export interface Row {
+  id: number;
+  release_name: string;
+  semver: string;
+  major: number;
+  minor: number;
+  patch: number;
+  year: number;
+  month: number;
+  label: string | null;
+  status: string;
+  release_type: string;
+  created_at: string;
+  created_by: string | null;
+  updated_at: string | null;
+  updated_by: string | null;
+}
+
+interface Props {
+  id: number;
+}
+
+export default function ReleaseRowDetail({ id }: Props) {
+  const [data, setData] = useState<Row | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleToggle(e: React.SyntheticEvent<HTMLDetailsElement>) {
+    const isOpen = e.currentTarget.open;
+    if (!isOpen || data || loading || error) return;
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/releases/${id}`);
+      if (!res.ok) throw new Error('fetch failed');
+      const json: Row = await res.json();
+      setData(json);
+      setError(null);
+    } catch {
+      setError('error');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  let content: React.ReactNode = null;
+  if (loading) {
+    content = <p>Loading…</p>;
+  } else if (error) {
+    content = <p>Error loading details</p>;
+  } else if (data) {
+    const fields: (keyof Row)[] = [
+      'id',
+      'release_name',
+      'semver',
+      'major',
+      'minor',
+      'patch',
+      'year',
+      'month',
+      'label',
+      'status',
+      'release_type',
+      'created_at',
+      'created_by',
+      'updated_at',
+      'updated_by',
+    ];
+    content = (
+      <dl>
+        {fields.map((key) => (
+          <Fragment key={key}>
+            <dt>{key}</dt>
+            <dd>{String(data[key] ?? '')}</dd>
+          </Fragment>
+        ))}
+      </dl>
+    );
+  }
+
+  return (
+    <details onToggle={handleToggle}>
+      <summary>Details</summary>
+      {content}
+    </details>
+  );
+}
+

--- a/jest.setup.env.ts
+++ b/jest.setup.env.ts
@@ -3,9 +3,8 @@ import dotenv from 'dotenv';
 // Load test env first
 dotenv.config({ path: '.env.test' });
 
-// Map TEST_DATABASE_URL -> DATABASE_URL for the app code
-if (process.env.TEST_DATABASE_URL && !process.env.DATABASE_URL) {
-  process.env.DATABASE_URL = process.env.TEST_DATABASE_URL;
+if (!process.env.TEST_DATABASE_URL) {
+  throw new Error('Missing env var: TEST_DATABASE_URL');
 }
 
 // Simulate Vercel environment for tests (non-prod)

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "validate-seo": "node scripts/validate-seo.mjs",
     "ci": "npm run lint && npm run images:optimize && npm run images:check && npm run validate-frontmatter && npm run validate-seo && npm run build",
     "typecheck": "tsc --noEmit",
-    "test": "jest",
+    "test": "cross-env NODE_ENV=test jest",
     "test:ci": "cross-env NODE_ENV=test jest --runInBand",
     "preci": "npm rebuild lightningcss --foreground-scripts && SHARP_IGNORE_GLOBAL_LIBVIPS=1 npm rebuild sharp --foreground-scripts",
     "pretest:e2e": "node -e \"require('fs').mkdirSync('.pw-browsers',{recursive:true})\"",


### PR DESCRIPTION
## Summary
- simplify release detail fetching by loading data when toggled open

## Testing
- `npx tsc --noEmit --types node,react,jest`
- `npm test` *(fails: Missing env var: TEST_DATABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_68acfb042c10832e9f3dbdd5b0b176e5