### PR TITLE
feat: add Bucks-styled YouTube wrapper

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -233,3 +233,18 @@ p {
   white-space: nowrap;
 }
 
+
+/* YouTube embed wrapper */
+.yt-wrapper-bucks {
+  background: var(--green);
+  padding: 1rem;
+  border-radius: 12px;
+}
+
+.yt-wrapper-bucks > iframe,
+.yt-wrapper-bucks > .youtube-embed {
+  display: block;
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  border: 0;
+}

--- a/app/roadwork-rappin/page.tsx
+++ b/app/roadwork-rappin/page.tsx
@@ -44,9 +44,8 @@ export default function Page() {
 
         <section aria-labelledby="video-title" className="space-y-4">
           <h2 id="video-title" className="text-xl font-semibold">Roadwork Rappin’ Video</h2>
-          <div className="relative aspect-video overflow-hidden rounded-xl">
+          <div className="yt-wrapper-bucks">
             <iframe
-              className="absolute inset-0 h-full w-full"
               src="https://www.youtube-nocookie.com/embed/jRHqjDnEFiE?si=-aVzrmGAmDuJ0PL0&loop=1&playlist=jRHqjDnEFiE"
               title="Aesop Rock — Roadwork Rappin’ music video"
               loading="lazy"


### PR DESCRIPTION
## Summary
- add `.yt-wrapper-bucks` class for responsive YouTube embeds with Bucks Green styling
- wrap Roadwork Rappin' video iframe with new reusable wrapper

## Testing
- `npm test` *(fails: Missing env var TEST_DATABASE_URL)*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68ae5a618ae8832eb3eb16b1a60bce02