### PR TITLE
Add DB diagnostics and release count endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ See [docs/authoring.md](docs/authoring.md) for the quickest way to scaffold and 
 
 This project requires a **Postgres** database.
 
-- `DATABASE_URL` – runtime connection string (falls back to `NEON_DATABASE_URL`)
+- `DATABASE_URL` – runtime connection string
 - `TEST_DATABASE_URL` – local tests
 
 For tests, create a `.env.test` file so `npm test` can load a dedicated database URL:
@@ -102,6 +102,8 @@ Verify connectivity:
 
 ```bash
 curl -s http://localhost:3000/api/_health
+curl -s http://localhost:3000/api/db-meta
+curl -s http://localhost:3000/api/releases-count
 curl -s "http://localhost:3000/api/releases?limit=5&offset=0&sort=created_at:desc"
 curl -s -X POST -H 'Content-Type: application/json' \
   -d '{"label":"Test patch"}' http://localhost:3000/api/releases/patch # mutates data

--- a/__tests__/db.smoke.test.ts
+++ b/__tests__/db.smoke.test.ts
@@ -9,18 +9,20 @@ jest.mock('@/db/pool', () => ({
   }),
 }));
 
+import type { QueryResult } from 'pg';
 import { getPool } from '@/db/pool';
 
 describe('database smoke test', () => {
   it('SELECT 1 returns 1', async () => {
-    const { rows } = await getPool().query<{ result: number }>('SELECT 1 as result');
-    expect(rows[0].result).toBe(1);
+    const res: QueryResult<{ result: number }> = await getPool().query('SELECT 1 as result');
+    expect(res.rows[0].result).toBe(1);
   });
 
   it('reports current database name', async () => {
-    const { rows } = await getPool().query<{ current_database: string }>(
+    const res: QueryResult<{ current_database: string }> = await getPool().query(
       'SELECT current_database()'
     );
-    expect(rows[0].current_database).toBe('test');
+    expect(res.rows[0].current_database).toBe('test');
   });
 });
+

--- a/app/api/db-meta/route.ts
+++ b/app/api/db-meta/route.ts
@@ -1,56 +1,68 @@
-import { Pool } from 'pg';
+import { Client, QueryResult } from 'pg';
 
 export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+function redact(u?: string | null) {
+  if (!u) return null;
+  try {
+    const url = new URL(u);
+    const hasUser = Boolean(url.username);
+    return `${url.protocol}//${hasUser ? '****@' : ''}${url.host}${url.pathname}`;
+  } catch {
+    return 'INVALID_URL';
+  }
+}
+
+type DbMetaRow = { db: string; usr: string; host_ip: string };
 
 export async function GET() {
-  const vercelEnv = process.env.VERCEL_ENV ?? process.env.NODE_ENV;
-  const url = process.env.DATABASE_URL;
-  if (!url) {
-    return Response.json({ vercelEnv, error: 'NO_OR_BAD_DATABASE_URL' }, { status: 500 });
-  }
-
-  let databaseUrlRedacted: string;
-  try {
-    const parsed = new URL(url);
-    databaseUrlRedacted = `${parsed.protocol}//${parsed.username ? '****@' : ''}${parsed.host}${parsed.pathname}`;
-  } catch {
-    return Response.json({ vercelEnv, error: 'NO_OR_BAD_DATABASE_URL' }, { status: 500 });
-  }
-
-  const pool = new Pool({ connectionString: url, max: 1, ssl: { rejectUnauthorized: false } });
-  let client;
-  try {
-    client = await pool.connect();
-  } catch (err) {
-    await pool.end();
-    return Response.json(
-      { vercelEnv, databaseUrlRedacted, error: 'CONNECTION_FAILED', reason: (err as Error).message },
-      { status: 500 },
-    );
-  }
+  const env = process.env.VERCEL_ENV ?? process.env.NODE_ENV ?? 'unknown';
+  const raw = process.env.DATABASE_URL;
+  const safe = redact(raw);
 
   try {
-    const metaRes = await client.query<{ current_database: string; current_user: string; inet_server_addr: string }>(
-      'SELECT current_database(), current_user, inet_server_addr()::text;',
-    );
-    const countRes = await client.query<{ count: number }>('SELECT COUNT(*)::int AS count FROM dojo.v_shaolin_scrolls;');
-    const meta = metaRes.rows[0] || { current_database: null, current_user: null, inet_server_addr: null };
-    return Response.json({
-      vercelEnv,
-      databaseUrlRedacted,
-      currentDatabase: meta.current_database,
-      currentUser: meta.current_user,
-      serverAddr: meta.inet_server_addr,
-      rowsInView: countRes.rows[0]?.count ?? 0,
+    if (!raw || safe === 'INVALID_URL') {
+      return Response.json(
+        { ok: false, reason: 'NO_OR_BAD_DATABASE_URL', vercelEnv: env, databaseUrlRedacted: safe },
+        { status: 500 },
+      );
+    }
+
+    const client = new Client({
+      connectionString: raw,
+      ssl: { rejectUnauthorized: false },
     });
-  } catch (err) {
+    await client.connect();
+
+    const metaRes: QueryResult<DbMetaRow> = await client.query(
+      `SELECT current_database() AS db,
+              current_user       AS usr,
+              inet_server_addr()::text AS host_ip`
+    );
+    const countRes: QueryResult<{ count: number }> = await client.query(
+      `SELECT COUNT(*)::int AS count FROM dojo.v_shaolin_scrolls`
+    );
+
+    await client.end();
+
+    const meta = metaRes.rows[0];
+    const count = countRes.rows[0]?.count ?? 0;
+
+    return Response.json({
+      ok: true,
+      vercelEnv: env,
+      databaseUrlRedacted: safe,
+      meta,
+      rowsInView: count,
+    });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
     return Response.json(
-      { vercelEnv, databaseUrlRedacted, error: 'QUERY_FAILED', reason: (err as Error).message },
+      { ok: false, reason: 'QUERY_FAILED', message, vercelEnv: env, databaseUrlRedacted: safe },
       { status: 500 },
     );
-  } finally {
-    client.release();
-    await pool.end();
   }
 }
 

--- a/app/api/db-meta/route.ts
+++ b/app/api/db-meta/route.ts
@@ -1,26 +1,56 @@
-// app/api/db-meta/route.ts (Next.js App Router)
 import { Pool } from 'pg';
 
-const url = process.env.DATABASE_URL!;
-const pool = new Pool({ connectionString: url, max: 1 });
+export const runtime = 'nodejs';
 
 export async function GET() {
-  const parsed = new URL(url);
-  const redacted = `${parsed.protocol}//${parsed.username ? '****@' : ''}${parsed.host}${parsed.pathname}`;
-  const { rows } = await pool.query(`
-    select
-      current_database() as db,
-      current_user as usr,
-      inet_server_addr()::text as host_ip,
-      version() as version
-  `);
-  return new Response(
-    JSON.stringify({
-      vercelEnv: process.env.VERCEL_ENV ?? process.env.NODE_ENV,
-      databaseUrlHost: parsed.host,     // good enough to tell prod vs staging
-      databaseUrlRedacted: redacted,    // safe to log to client
-      meta: rows[0],
-    }),
-    { headers: { 'content-type': 'application/json' } }
-  );
+  const vercelEnv = process.env.VERCEL_ENV ?? process.env.NODE_ENV;
+  const url = process.env.DATABASE_URL;
+  if (!url) {
+    return Response.json({ vercelEnv, error: 'NO_OR_BAD_DATABASE_URL' }, { status: 500 });
+  }
+
+  let databaseUrlRedacted: string;
+  try {
+    const parsed = new URL(url);
+    databaseUrlRedacted = `${parsed.protocol}//${parsed.username ? '****@' : ''}${parsed.host}${parsed.pathname}`;
+  } catch {
+    return Response.json({ vercelEnv, error: 'NO_OR_BAD_DATABASE_URL' }, { status: 500 });
+  }
+
+  const pool = new Pool({ connectionString: url, max: 1, ssl: { rejectUnauthorized: false } });
+  let client;
+  try {
+    client = await pool.connect();
+  } catch (err) {
+    await pool.end();
+    return Response.json(
+      { vercelEnv, databaseUrlRedacted, error: 'CONNECTION_FAILED', reason: (err as Error).message },
+      { status: 500 },
+    );
+  }
+
+  try {
+    const metaRes = await client.query<{ current_database: string; current_user: string; inet_server_addr: string }>(
+      'SELECT current_database(), current_user, inet_server_addr()::text;',
+    );
+    const countRes = await client.query<{ count: number }>('SELECT COUNT(*)::int AS count FROM dojo.v_shaolin_scrolls;');
+    const meta = metaRes.rows[0] || { current_database: null, current_user: null, inet_server_addr: null };
+    return Response.json({
+      vercelEnv,
+      databaseUrlRedacted,
+      currentDatabase: meta.current_database,
+      currentUser: meta.current_user,
+      serverAddr: meta.inet_server_addr,
+      rowsInView: countRes.rows[0]?.count ?? 0,
+    });
+  } catch (err) {
+    return Response.json(
+      { vercelEnv, databaseUrlRedacted, error: 'QUERY_FAILED', reason: (err as Error).message },
+      { status: 500 },
+    );
+  } finally {
+    client.release();
+    await pool.end();
+  }
 }
+

--- a/app/api/releases-count/route.ts
+++ b/app/api/releases-count/route.ts
@@ -1,5 +1,6 @@
 import { getPool } from '@/db/pool';
 import { logger } from '@/app/lib/server-logger';
+import type { QueryResult } from 'pg';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -7,8 +8,8 @@ export const dynamic = 'force-dynamic';
 export async function GET() {
   try {
     const db = getPool();
-    const { rows } = await db.query<{ count: number }>('SELECT COUNT(*)::int AS count FROM dojo.v_shaolin_scrolls;');
-    return Response.json({ count: rows[0]?.count ?? 0 });
+    const res: QueryResult<{ count: number }> = await db.query('SELECT COUNT(*)::int AS count FROM dojo.v_shaolin_scrolls;');
+    return Response.json({ count: res.rows[0]?.count ?? 0 });
   } catch (err) {
     logger.error('releases-count failed:', err);
     return Response.json({ count: 0, error: 'database error' }, { status: 500 });

--- a/app/api/releases-count/route.ts
+++ b/app/api/releases-count/route.ts
@@ -1,0 +1,17 @@
+import { getPool } from '@/db/pool';
+import { logger } from '@/app/lib/server-logger';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  try {
+    const db = getPool();
+    const { rows } = await db.query<{ count: number }>('SELECT COUNT(*)::int AS count FROM dojo.v_shaolin_scrolls;');
+    return Response.json({ count: rows[0]?.count ?? 0 });
+  } catch (err) {
+    logger.error('releases-count failed:', err);
+    return Response.json({ count: 0, error: 'database error' }, { status: 500 });
+  }
+}
+

--- a/app/api/releases/[id]/route.ts
+++ b/app/api/releases/[id]/route.ts
@@ -1,6 +1,7 @@
 import type { NextRequest } from 'next/server';
 import { getPool } from '@/db/pool';
 import { logger } from '@/app/lib/server-logger';
+import type { QueryResult } from 'pg';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -47,8 +48,8 @@ export async function GET(
 
   try {
     const db = getPool();
-    const { rows } = await db.query<ReleaseRow>(sql, [numId]);
-    const row = rows[0];
+    const res: QueryResult<ReleaseRow> = await db.query(sql, [numId]);
+    const row = res.rows[0];
     if (!row) {
       return Response.json({ error: 'not found' }, { status: 404 });
     }
@@ -68,3 +69,4 @@ export async function GET(
     return Response.json({ error: 'database error' }, { status: 500 });
   }
 }
+

--- a/app/api/releases/minor/route.ts
+++ b/app/api/releases/minor/route.ts
@@ -1,5 +1,6 @@
 import { getPool } from '@/db/pool';
 import { logger } from '@/app/lib/server-logger';
+import type { QueryResult } from 'pg';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -33,8 +34,8 @@ export async function POST(req: Request) {
   const sql = 'SELECT * FROM dojo.fn_next_minor($1::text);';
   try {
     const db = getPool();
-    const { rows } = await db.query<DbRow>(sql, [label]);
-    const row = rows[0];
+    const res: QueryResult<DbRow> = await db.query(sql, [label]);
+    const row = res.rows[0];
     const item: Row = { id: String(row.scroll_id), generated_name: row.generated_name };
     return Response.json(item);
   } catch (err) {
@@ -42,3 +43,4 @@ export async function POST(req: Request) {
     return Response.json({ error: 'database error' }, { status: 500 });
   }
 }
+

--- a/app/api/releases/patch/route.ts
+++ b/app/api/releases/patch/route.ts
@@ -1,5 +1,6 @@
 import { getPool } from '@/db/pool';
 import { logger } from '@/app/lib/server-logger';
+import type { QueryResult } from 'pg';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -33,8 +34,8 @@ export async function POST(req: Request) {
   const sql = 'SELECT * FROM dojo.fn_next_patch($1::text);';
   try {
     const db = getPool();
-    const { rows } = await db.query<DbRow>(sql, [label]);
-    const row = rows[0];
+    const res: QueryResult<DbRow> = await db.query(sql, [label]);
+    const row = res.rows[0];
     const item: Row = { id: String(row.scroll_id), generated_name: row.generated_name };
     return Response.json(item);
   } catch (err) {
@@ -42,3 +43,4 @@ export async function POST(req: Request) {
     return Response.json({ error: 'database error' }, { status: 500 });
   }
 }
+

--- a/app/api/releases/route.ts
+++ b/app/api/releases/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { logger } from '@/app/lib/server-logger';
 import { getPool } from '@/db/pool';
+import type { QueryResult } from 'pg';
 import type { ReleaseListItem, PageMeta, ReleaseListResponse } from '@/types/releases';
 
 type RawReleaseItem = Omit<ReleaseListItem, 'created_at'> & { created_at: Date | string };
@@ -58,9 +59,9 @@ export async function GET(req: Request) {
     `;
 
     const db = getPool();
-    const [itemsRes, countRes] = await Promise.all([
-      db.query<RawReleaseItem>(sqlItems, values),
-      db.query<{ total: number }>(sqlCount, countValues),
+    const [itemsRes, countRes]: [QueryResult<RawReleaseItem>, QueryResult<{ total: number }>] = await Promise.all([
+      db.query(sqlItems, values),
+      db.query(sqlCount, countValues),
     ]);
 
     const items: ReleaseListItem[] = itemsRes.rows.map((row) => ({
@@ -77,3 +78,4 @@ export async function GET(req: Request) {
     return NextResponse.json({ error: 'database error' }, { status: 500 });
   }
 }
+

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -1,1 +1,1 @@
-export const DATABASE_URL = process.env.DATABASE_URL ?? process.env.NEON_DATABASE_URL ?? null;
+export const DATABASE_URL = process.env.DATABASE_URL ?? null;


### PR DESCRIPTION
## Summary
- add /api/db-meta diagnostic endpoint to inspect database connection
- add /api/releases-count endpoint for quick smoke checks
- rely solely on DATABASE_URL for PG access

## Testing
- `TEST_DATABASE_URL=postgres://dummy npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aea44b3838832e923cc6e5dd3ed909