### PR TITLE
feat: guard production db env and add env inspection route

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ This project requires a **Postgres** database.
 - `DATABASE_URL` – runtime connection string
 - `TEST_DATABASE_URL` – local tests
 
+Set `NEXT_PUBLIC_DEBUG_DB_META=1` to expose `/api/env-check` with redacted database env vars for debugging.
+
 For tests, create a `.env.test` file so `npm test` can load a dedicated database URL:
 
 ```bash

--- a/app/api/db-meta/route.ts
+++ b/app/api/db-meta/route.ts
@@ -1,4 +1,5 @@
 import { Client, QueryResult } from 'pg';
+import { assertValidDatabaseUrl } from '@/db/assert-database-url';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -19,7 +20,8 @@ type DbMetaRow = { db: string; usr: string; host_ip: string };
 
 export async function GET() {
   const env = process.env.VERCEL_ENV ?? process.env.NODE_ENV ?? 'unknown';
-  const raw = process.env.DATABASE_URL;
+  const raw = process.env.DATABASE_URL ?? null;
+  assertValidDatabaseUrl(raw);
   const safe = redact(raw);
 
   try {

--- a/app/api/env-check/route.ts
+++ b/app/api/env-check/route.ts
@@ -1,0 +1,43 @@
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+function redact(u: string | null | undefined) {
+  if (!u) return null;
+  try {
+    const url = new URL(u);
+    const hasUser = Boolean(url.username);
+    return `${url.protocol}//${hasUser ? '****@' : ''}${url.host}${url.pathname}`;
+  } catch {
+    return 'INVALID_URL';
+  }
+}
+
+const VARS = [
+  'DATABASE_URL',
+  'POSTGRES_URL',
+  'POSTGRES_PRISMA_URL',
+  'NEON_DATABASE_URL',
+  'PGDATABASE_URL',
+] as const;
+
+export async function GET() {
+  if (process.env.NEXT_PUBLIC_DEBUG_DB_META !== '1') {
+    return new Response('Not Found', { status: 404 });
+  }
+  const data: Record<(typeof VARS)[number], string | null> = {
+    DATABASE_URL: null,
+    POSTGRES_URL: null,
+    POSTGRES_PRISMA_URL: null,
+    NEON_DATABASE_URL: null,
+    PGDATABASE_URL: null,
+  };
+  for (const key of VARS) {
+    const raw = process.env[key];
+    data[key] = redact(raw);
+  }
+  return Response.json(data);
+}
+
+export default function NotFound() {
+  return new Response('Not Found', { status: 404 });
+}

--- a/app/api/env-check/route.ts
+++ b/app/api/env-check/route.ts
@@ -1,5 +1,6 @@
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
+export const revalidate = 0;
 
 function redact(u: string | null | undefined) {
   if (!u) return null;
@@ -24,7 +25,9 @@ export async function GET() {
   if (process.env.NEXT_PUBLIC_DEBUG_DB_META !== '1') {
     return new Response('Not Found', { status: 404 });
   }
-  const data: Record<(typeof VARS)[number], string | null> = {
+  const env = process.env.VERCEL_ENV ?? process.env.NODE_ENV ?? 'unknown';
+  const data: { vercelEnv: string } & Record<(typeof VARS)[number], string | null> = {
+    vercelEnv: env,
     DATABASE_URL: null,
     POSTGRES_URL: null,
     POSTGRES_PRISMA_URL: null,
@@ -32,12 +35,7 @@ export async function GET() {
     PGDATABASE_URL: null,
   };
   for (const key of VARS) {
-    const raw = process.env[key];
-    data[key] = redact(raw);
+    data[key] = redact(process.env[key]);
   }
   return Response.json(data);
-}
-
-export default function NotFound() {
-  return new Response('Not Found', { status: 404 });
 }

--- a/db/assert-database-url.ts
+++ b/db/assert-database-url.ts
@@ -1,0 +1,16 @@
+export function assertValidDatabaseUrl(url: string | null) {
+  if (process.env.VERCEL_ENV === 'production' && url) {
+    try {
+      const parsed = new URL(url);
+      const badUser = parsed.username === 'neondb_owner';
+      const badDb = parsed.pathname.endsWith('/neondb');
+      if (badUser || badDb) {
+        throw new Error(
+          'Invalid DATABASE_URL: neondb_owner/neondb detected. Update Production env to use tullyelly_admin and tullyelly_db.',
+        );
+      }
+    } catch {
+      // Ignore parse errors; other checks will handle missing or bad URLs.
+    }
+  }
+}

--- a/db/pool.ts
+++ b/db/pool.ts
@@ -1,11 +1,13 @@
 import { Pool } from 'pg';
 import { DATABASE_URL } from '@/lib/env';
+import { assertValidDatabaseUrl } from '@/db/assert-database-url';
 
 let pool: Pool | undefined;
 
 export function getPool() {
   if (!pool) {
     if (!DATABASE_URL) throw new Error('Missing DATABASE_URL');
+    assertValidDatabaseUrl(DATABASE_URL);
     pool = new Pool({ connectionString: DATABASE_URL, ssl: { rejectUnauthorized: false } });
   }
   return pool;


### PR DESCRIPTION
## Summary
- add `/api/env-check` route gated by `NEXT_PUBLIC_DEBUG_DB_META`
- assert production `DATABASE_URL` doesn't use `neondb_owner/neondb`
- document debug flag in README

## Testing
- `npm run typecheck`
- `npx vercel env ls` *(fails: No existing credentials found)*

------
https://chatgpt.com/codex/tasks/task_e_68aead195cbc832ea772102046780bc2