### PR TITLE
Add robots and sitemap metadata routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,12 @@ See [docs/authoring.md](docs/authoring.md) for the quickest way to scaffold and 
 
 ---
 
+## 🌐 SEO & Crawl Directives
+
+Robots and sitemap metadata routes live in `app/robots.ts` and `app/sitemap.ts`, providing baseline crawl directives and a simple sitemap for top-level pages.
+
+---
+
 ## 🗃️ Database
 
 This project requires a **Postgres** database.

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,17 @@
+import type { MetadataRoute } from "next";
+
+const baseUrl = "https://tullyelly.com";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+      },
+    ],
+    host: baseUrl,
+    sitemap: `${baseUrl}/sitemap.xml`,
+  };
+}
+

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,37 @@
+import type { MetadataRoute } from "next";
+
+const baseUrl = "https://tullyelly.com";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return [
+    {
+      url: baseUrl,
+      lastModified: new Date(),
+    },
+    {
+      url: `${baseUrl}/scrolls`,
+      lastModified: new Date(),
+    },
+    {
+      url: `${baseUrl}/shaolin-scrolls`,
+      lastModified: new Date(),
+    },
+    {
+      url: `${baseUrl}/heels-have-eyes`,
+      lastModified: new Date(),
+    },
+    {
+      url: `${baseUrl}/roadwork-rappin`,
+      lastModified: new Date(),
+    },
+    {
+      url: `${baseUrl}/ui-lab`,
+      lastModified: new Date(),
+    },
+    {
+      url: `${baseUrl}/typography-demo`,
+      lastModified: new Date(),
+    },
+  ];
+}
+


### PR DESCRIPTION
## Summary
- add Next.js metadata routes for robots directives and sitemap
- list top-level pages in sitemap and reference it from robots
- document SEO routes in README

## Testing
- `TEST_DATABASE_URL=postgres://user:pass@localhost:5432/db npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aeb64f3e98832e8f7b9b10ff166deb