### PR TITLE
feat: add security headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,3 +179,4 @@ This repo is already structured for one-click deploys.
 * Set `NEXT_PUBLIC_ANNOUNCEMENT` to display the top banner
 * Always run `npm run images:optimize` before committing new images
 * `app/scrolls`: responsive grid layout with sidebar and table scaffold
+* Security headers configured in `next.config.mjs` enforce HSTS, deny framing, and prevent MIME sniffing.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -16,6 +16,21 @@ const nextConfig = {
   images: {
     // Use Next.js defaults; no custom loader/path.
   },
+  async headers() {
+    return [
+      {
+        source: '/(.*)',
+        headers: [
+          {
+            key: 'Strict-Transport-Security',
+            value: 'max-age=63072000; includeSubDomains; preload',
+          },
+          { key: 'X-Frame-Options', value: 'DENY' },
+          { key: 'X-Content-Type-Options', value: 'nosniff' },
+        ],
+      },
+    ];
+  },
 };
 
 export default withMDX(nextConfig);


### PR DESCRIPTION
## Summary
- add HSTS, frame, and sniffing protections via headers
- document global security headers

## Testing
- `npm test` *(fails: Missing env var: TEST_DATABASE_URL)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aeb6424d20832e8988dc62d0e98479