### PR TITLE
chore: enable strict TypeScript mode

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
-    "strict": false,
+    "strict": true,
     "noEmit": true,
     "incremental": true,
     "module": "esnext",


### PR DESCRIPTION
## Summary
- enable TypeScript strict mode in `tsconfig.json`

## Testing
- `TEST_DATABASE_URL=postgresql://user:pass@localhost:5432/db npm test`
- `npm run lint`
- `npm run typecheck` *(fails: Could not find declaration file for module 'jest-axe'; implicit any index errors in ScrollsTable components)*

------
https://chatgpt.com/codex/tasks/task_e_68aeb628df34832e9b55dc43ee307d2d