### PR TITLE
fix: read NEON database url

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ See [docs/authoring.md](docs/authoring.md) for the quickest way to scaffold and 
 
 This project requires a **Postgres** database.
 
-- `DATABASE_URL` – runtime connection string
+- `NEON_DATABASE_URL` – runtime connection string (falls back to `DATABASE_URL`)
 - `TEST_DATABASE_URL` – local tests
 
 Set `NEXT_PUBLIC_DEBUG_DB_META=1` to expose `/api/env-check` with redacted database env vars for debugging.

--- a/app/api/db-meta/route.ts
+++ b/app/api/db-meta/route.ts
@@ -1,5 +1,6 @@
 import { Client, QueryResult } from 'pg';
 import { assertValidDatabaseUrl } from '@/db/assert-database-url';
+import { DATABASE_URL } from '@/lib/env';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -20,7 +21,7 @@ type DbMetaRow = { db: string; usr: string; host_ip: string };
 
 export async function GET() {
   const env = process.env.VERCEL_ENV ?? process.env.NODE_ENV ?? 'unknown';
-  const raw = process.env.DATABASE_URL ?? null;
+  const raw = DATABASE_URL;
   assertValidDatabaseUrl(raw);
   const safe = redact(raw);
 

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -1,1 +1,1 @@
-export const DATABASE_URL = process.env.DATABASE_URL ?? null;
+export const DATABASE_URL = process.env.NEON_DATABASE_URL ?? process.env.DATABASE_URL ?? null;


### PR DESCRIPTION
## Summary
- fallback to `NEON_DATABASE_URL` for Postgres connections
- use shared env constant in db meta route
- document new env variable

## Testing
- `npm run lint`
- `npm test` *(fails: Missing env var: TEST_DATABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_68aec18a2254832e837857cfd6c34f6c