### PR TITLE
Fix YouTube embed for Heels Have Eyes page

### DIFF
--- a/app/heels-have-eyes/page.tsx
+++ b/app/heels-have-eyes/page.tsx
@@ -72,7 +72,7 @@ export default function Page() {
           <figure className="space-y-2">
             <div className="yt-wrapper-bucks">
               <iframe
-                src="https://www.youtube.com/watch?v=-mnJEnjyaY4"
+                src="https://www.youtube-nocookie.com/embed/-mnJEnjyaY4?si=LMJt5-8BmEL4cFlQ"
                 title="Westside Gunn — DAVEY BOY SMITH music video"
                 loading="lazy"
                 allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"


### PR DESCRIPTION
## Summary
- use YouTube privacy-enhanced embed for Heels Have Eyes video

## Testing
- `npm test` *(fails: Missing env var TEST_DATABASE_URL)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af3c2ef57c832ea4e8c72d31dd2fb9