### PR TITLE
feat: add release fetch helpers and diagnostics

### DIFF
--- a/app/api/diag/route.ts
+++ b/app/api/diag/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+export async function GET() {
+  return NextResponse.json(
+    {
+      ok: true,
+      env: process.env.NODE_ENV,
+      vercel_url: process.env.VERCEL_URL ?? null,
+      site_url: process.env.SITE_URL ?? null,
+      ts: new Date().toISOString(),
+    },
+    { headers: { "Cache-Control": "no-store" } }
+  );
+}

--- a/app/api/releases/route.ts
+++ b/app/api/releases/route.ts
@@ -6,6 +6,7 @@ import type { QueryResult } from 'pg';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
+export const revalidate = 0;
 
 const ORDER_BY = {
   'semver:desc': `ORDER BY
@@ -137,7 +138,14 @@ export async function GET(req: Request) {
     const page: PageMeta = { limit, offset, total, sort };
     if (q) page.q = q;
 
-    return NextResponse.json({ items, page } as ReleaseListResponse);
+    return NextResponse.json(
+      { items, page } as ReleaseListResponse,
+      {
+        headers: {
+          'Cache-Control': 'no-store, no-cache, must-revalidate',
+        },
+      }
+    );
   } catch (err) {
     if (err instanceof InputError) {
       console.error('[API:/releases] bad input', err); // eslint-disable-line no-console

--- a/app/lib/fetchReleases.ts
+++ b/app/lib/fetchReleases.ts
@@ -1,0 +1,58 @@
+import { getBaseUrl } from "./getBaseUrl";
+import type { ReleaseListResponse, ReleaseRow } from "@/types/releases";
+
+export async function fetchReleases(): Promise<ReleaseRow[]> {
+  const base = getBaseUrl();
+  const url = `${base}/api/releases`;
+
+  console.log(
+    JSON.stringify({
+      tag: "releases_fetch_begin",
+      url,
+      env: process.env.NODE_ENV,
+      vercel_url: process.env.VERCEL_URL ?? null,
+    })
+  );
+
+  const res = await fetch(url, {
+    cache: "no-store",
+    next: { revalidate: 0 },
+    headers: {
+      "x-ssr-fetch": "releases",
+    },
+  });
+
+  if (!res.ok) {
+    console.error(
+      JSON.stringify({
+        tag: "releases_fetch_http_error",
+        status: res.status,
+        statusText: res.statusText,
+        url,
+      })
+    );
+    throw new Error(`Failed to fetch releases: ${res.status}`);
+  }
+
+  const json = (await res.json()) as ReleaseListResponse;
+
+  if (!json || !Array.isArray(json.items)) {
+    console.error(
+      JSON.stringify({
+        tag: "releases_fetch_bad_payload",
+        url,
+        payloadKeys: json ? Object.keys(json) : null,
+      })
+    );
+    throw new Error("Unexpected releases payload");
+  }
+
+  console.log(
+    JSON.stringify({
+      tag: "releases_fetch_success",
+      count: json.items.length,
+    })
+  );
+
+  return json.items;
+}

--- a/app/lib/getBaseUrl.ts
+++ b/app/lib/getBaseUrl.ts
@@ -1,0 +1,13 @@
+export function getBaseUrl() {
+  // 1) Client: use relative
+  if (typeof window !== "undefined") return "";
+
+  // 2) Vercel: use VERCEL_URL (no protocol)
+  if (process.env.VERCEL_URL) return `https://${process.env.VERCEL_URL}`;
+
+  // 3) Fallback: use SITE_URL if provided
+  if (process.env.SITE_URL) return process.env.SITE_URL;
+
+  // 4) Dev/server fallback
+  return "http://localhost:3000";
+}

--- a/app/releases/page.tsx
+++ b/app/releases/page.tsx
@@ -1,0 +1,24 @@
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+import { fetchReleases } from "@/app/lib/fetchReleases";
+
+export default async function ReleasesPage() {
+  const releases = await fetchReleases();
+  return (
+    <main className="p-6">
+      <h1 className="text-2xl font-semibold">Releases</h1>
+      {releases.length === 0 ? (
+        <p className="opacity-70">No releases yet.</p>
+      ) : (
+        <ul className="mt-4 space-y-2">
+          {releases.map((r) => (
+            <li key={r.id} className="rounded border p-3">
+              <pre className="text-sm">{JSON.stringify(r, null, 2)}</pre>
+            </li>
+          ))}
+        </ul>
+      )}
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add base URL helper and release fetcher with structured logs
- expose diagnostic API and make releases API no-cache
- add dynamic releases page

## Testing
- `npm test` *(fails: Missing env var: TEST_DATABASE_URL)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af44045014832e8005752265767182