### PR TITLE
fix: disable caching for scrolls table data

### DIFF
--- a/app/scrolls/page.tsx
+++ b/app/scrolls/page.tsx
@@ -7,6 +7,7 @@ import ScrollsTable from './components/ScrollsTable';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
+export const revalidate = 0;
 
 interface PageProps {
   searchParams: Promise<{ limit?: string; offset?: string; sort?: string; q?: string }>;
@@ -27,6 +28,7 @@ export default async function Page({ searchParams }: PageProps) {
     const base = process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : 'http://localhost:3000';
     const res = await fetch(`${base}/api/releases?${params.toString()}`, {
       cache: 'no-store',
+      next: { revalidate: 0 },
     });
     if (res.ok) data = await res.json();
   } catch (err) {

--- a/app/shaolin-scrolls/page.tsx
+++ b/app/shaolin-scrolls/page.tsx
@@ -7,6 +7,7 @@ import styles from './page.module.css';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
+export const revalidate = 0;
 
 interface PageProps {
   searchParams: Promise<{
@@ -38,6 +39,7 @@ export default async function Page({ searchParams }: PageProps) {
     const base = process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : 'http://localhost:3000';
     const res = await fetch(`${base}/api/releases?${params.toString()}`, {
       cache: 'no-store',
+      next: { revalidate: 0 },
     });
     if (res.ok) data = await res.json();
   } catch (err) {


### PR DESCRIPTION
## Summary
- force dynamic rendering on scrolls pages
- fetch releases data without caching to prevent stale results

## Testing
- `npm test` *(fails: Missing env var TEST_DATABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_68af4f8877c0832e8ddedf8319e374dc