### PR TITLE
feat: patch dialog and db function

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,17 @@ jobs:
         with:
           fetch-depth: 0
 
-      # composite setup (node, cache, deps)
-      - uses: ./.github/actions/setup
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Clean install
+        run: npm ci --include=optional
+
+      - name: Verify critical deps present
+        run: npm run verify:deps
 
       # sanity-check native bindings
       - name: Verify sharp binding
@@ -142,7 +151,14 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: ./.github/actions/setup
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Clean install
+        run: npm ci --include=optional
 
       - name: Get Playwright version
         id: playwright-version

--- a/.github/workflows/lock-sync.yml
+++ b/.github/workflows/lock-sync.yml
@@ -1,0 +1,20 @@
+name: Lockfile Sync Check
+on:
+  pull_request:
+    paths:
+      - "package.json"
+      - "package-lock.json"
+jobs:
+  lockfile-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Ensure lockfile updated when package.json changes
+        run: |
+          CHANGED_FILES="$(git diff --name-only HEAD^ HEAD || true)"
+          if echo "$CHANGED_FILES" | grep -qx "package.json" && \
+             ! echo "$CHANGED_FILES" | grep -qx "package-lock.json"; then
+            echo "::error ::package.json changed but package-lock.json did not. Run 'npm install' and commit the lockfile."
+            exit 1
+          fi
+

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ curl -s "http://localhost:3000/api/releases?q=scroll"
 
 # Mutations (creates new releases)
 curl -s -X POST -H 'Content-Type: application/json' \
-  -d '{"label":"Test patch"}' http://localhost:3000/api/releases/patch
+  -d '{"label":"Test patch","statusCode":"planned","releaseTypeCode":"hotfix"}' http://localhost:3000/api/releases/patch
 
 curl -s -X POST -H 'Content-Type: application/json' \
   -d '{"label":"Test minor"}' http://localhost:3000/api/releases/minor

--- a/app/api/meta/release-status/route.ts
+++ b/app/api/meta/release-status/route.ts
@@ -1,0 +1,11 @@
+import { getPool } from '@/db/pool';
+import { NextResponse } from 'next/server';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  const db = getPool();
+  const res = await db.query('SELECT id, code FROM dojo.release_status ORDER BY code ASC;');
+  return NextResponse.json(res.rows);
+}

--- a/app/api/meta/release-type/route.ts
+++ b/app/api/meta/release-type/route.ts
@@ -1,0 +1,11 @@
+import { getPool } from '@/db/pool';
+import { NextResponse } from 'next/server';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  const db = getPool();
+  const res = await db.query('SELECT id, code FROM dojo.release_type ORDER BY code ASC;');
+  return NextResponse.json(res.rows);
+}

--- a/app/api/releases/patch/route.ts
+++ b/app/api/releases/patch/route.ts
@@ -5,7 +5,7 @@ export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
 // curl -s -X POST -H 'Content-Type: application/json' \
-//   -d '{"label":"First hotfix"}' http://localhost:3000/api/releases/patch
+//   -d '{"label":"First hotfix","statusCode":"planned","releaseTypeCode":"hotfix"}' http://localhost:3000/api/releases/patch
 
 interface DbRow {
   scroll_id: number;
@@ -17,23 +17,32 @@ export type Row = {
   generated_name: string;
 };
 
+type Body = {
+  label: string;
+  statusCode: string;
+  releaseTypeCode: string;
+};
+
 export async function POST(req: Request) {
-  let label: string;
+  let body: Body;
   try {
-    const body = await req.json();
-    label = typeof body.label === 'string' ? body.label.trim() : '';
+    body = (await req.json()) as Body;
   } catch {
     return Response.json({ error: 'invalid body' }, { status: 400 });
   }
 
-  if (!label || label.length > 120) {
-    return Response.json({ error: 'invalid label' }, { status: 400 });
+  const label = typeof body.label === 'string' ? body.label.trim() : '';
+  const status = typeof body.statusCode === 'string' ? body.statusCode.trim() : '';
+  const rtype = typeof body.releaseTypeCode === 'string' ? body.releaseTypeCode.trim() : '';
+
+  if (!label || label.length > 120 || !status || !rtype) {
+    return Response.json({ error: 'missing fields' }, { status: 400 });
   }
 
-  const sql = 'SELECT * FROM dojo.fn_next_patch($1::text);';
+  const sql = 'SELECT * FROM dojo.fn_next_patch($1::text, $2::text, $3::text);';
   try {
     const db = getPool();
-    const res: QueryResult<DbRow> = await db.query(sql, [label]);
+    const res: QueryResult<DbRow> = await db.query(sql, [label, status, rtype]);
     const row = res.rows[0];
     const item: Row = { id: String(row.scroll_id), generated_name: row.generated_name };
     return Response.json(item);
@@ -42,4 +51,3 @@ export async function POST(req: Request) {
     return Response.json({ error: 'database error' }, { status: 500 });
   }
 }
-

--- a/app/shaolin-scrolls/CreatePatchDialog.tsx
+++ b/app/shaolin-scrolls/CreatePatchDialog.tsx
@@ -1,0 +1,136 @@
+'use client';
+
+import * as React from 'react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Select, SelectTrigger, SelectContent, SelectItem, SelectValue } from '@/components/ui/select';
+
+type Option = { id: number; code: string };
+
+export default function CreatePatchDialog({ onCreated }: { onCreated?: () => void }) {
+  const [open, setOpen] = React.useState(false);
+  const [label, setLabel] = React.useState('');
+  const [status, setStatus] = React.useState('');
+  const [rtype, setRtype] = React.useState('');
+
+  const [statusOpts, setStatusOpts] = React.useState<Option[]>([]);
+  const [typeOpts, setTypeOpts] = React.useState<Option[]>([]);
+  const [loading, setLoading] = React.useState(false);
+  const [resultName, setResultName] = React.useState<string | null>(null);
+  const [error, setError] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    (async () => {
+      const [s, t] = await Promise.all([
+        fetch('/api/meta/release-status').then(r => r.json()),
+        fetch('/api/meta/release-type').then(r => r.json()),
+      ]);
+      setStatusOpts(s);
+      setTypeOpts(t);
+    })();
+  }, []);
+
+  async function submit() {
+    setLoading(true);
+    setError(null);
+    setResultName(null);
+    try {
+      const res = await fetch('/api/releases/patch', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          label: label.trim(),
+          statusCode: status,
+          releaseTypeCode: rtype,
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data?.error ?? 'Request failed');
+      setResultName(data?.generated_name ?? null);
+      onCreated?.();
+    } catch (e: any) {
+      setError(e.message);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function resetAndClose() {
+    setOpen(false);
+    setLabel('');
+    setStatus('');
+    setRtype('');
+    setError(null);
+    setResultName(null);
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button>Create Patch</Button>
+      </DialogTrigger>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Create Patch</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4">
+          <div>
+            <label className="mb-1 block text-sm">Label</label>
+            <Input
+              placeholder="e.g., optimize ci e2e pipeline"
+              value={label}
+              onChange={(e) => setLabel(e.target.value)}
+            />
+          </div>
+          <div>
+            <label className="mb-1 block text-sm">Status</label>
+            <Select value={status} onValueChange={setStatus}>
+              <SelectTrigger>
+                <SelectValue placeholder="Choose a status" />
+              </SelectTrigger>
+              <SelectContent>
+                {statusOpts.map(o => (
+                  <SelectItem key={o.id} value={o.code}>
+                    {o.code}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div>
+            <label className="mb-1 block text-sm">Release Type</label>
+            <Select value={rtype} onValueChange={setRtype}>
+              <SelectTrigger>
+                <SelectValue placeholder="Choose a release type" />
+              </SelectTrigger>
+              <SelectContent>
+                {typeOpts.map(o => (
+                  <SelectItem key={o.id} value={o.code}>
+                    {o.code}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          {error && <p className="text-sm text-red-600">{error}</p>}
+          {resultName && (
+            <div className="rounded-md border p-3 text-sm">
+              <div className="mb-1 font-medium">Created</div>
+              <div className="select-all">{resultName}</div>
+              <div className="mt-1 text-xs text-neutral-500">Copy for Jira.</div>
+            </div>
+          )}
+          <div className="flex justify-end gap-2">
+            <Button onClick={resetAndClose} variant="outline">
+              Cancel
+            </Button>
+            <Button onClick={submit} disabled={loading || !label.trim() || !status || !rtype}>
+              {loading ? 'Creating…' : 'Create'}
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/app/shaolin-scrolls/_components/ScrollsTable.tsx
+++ b/app/shaolin-scrolls/_components/ScrollsTable.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import {
   ColumnDef,
   flexRender,
@@ -102,15 +102,12 @@ export function ScrollsTable({
   isLoading?: boolean;
 }) {
   const [scrolled, setScrolled] = useState(false);
-  const containerRef = useRef<HTMLDivElement>(null);
   const memoData = useMemo(() => data, [data]);
 
   useEffect(() => {
-    const el = containerRef.current;
-    if (!el) return;
-    const onScroll = () => setScrolled(el.scrollTop > 0);
-    el.addEventListener('scroll', onScroll);
-    return () => el.removeEventListener('scroll', onScroll);
+    const onScroll = () => setScrolled(window.scrollY > 0);
+    window.addEventListener('scroll', onScroll);
+    return () => window.removeEventListener('scroll', onScroll);
   }, []);
 
   const table = useReactTable({
@@ -131,7 +128,7 @@ export function ScrollsTable({
   return (
     <div id="scrolls-table" data-build={BUILD} className="flex h-full flex-col">
       <div className="mb-2 text-xs text-neutral-500">Build: {BUILD}</div>
-      <div ref={containerRef} className="flex-1 min-h-0 rounded-xl border overflow-auto">
+      <div className="flex-1 min-h-0 rounded-xl border">
         <table className="table-fixed w-full border-separate border-spacing-0">
           <thead className={`sticky top-0 bg-white ${scrolled ? 'shadow-sm' : ''}`}>
             {table.getHeaderGroups().map(hg => (
@@ -140,7 +137,7 @@ export function ScrollsTable({
                   <th
                     key={h.id}
                     style={{ width: h.getSize() }}
-                    className={`px-3 py-2 text-xs font-semibold uppercase tracking-wide align-middle ${h.column.columnDef.meta?.headerClassName ?? ''}`}
+                    className={`rounded px-3 py-2 text-xs font-semibold uppercase tracking-wide align-middle ${h.column.columnDef.meta?.headerClassName ?? ''}`}
                   >
                     {h.isPlaceholder ? null : (
                       <button
@@ -170,7 +167,7 @@ export function ScrollsTable({
               Array.from({ length: pageSize }).map((_, i) => (
                 <tr key={i} className="odd:bg-neutral-50">
                   {columns.map((col, idx) => (
-                    <td key={col.id ?? idx} style={{ width: col.size }} className="px-3 py-2">
+                    <td key={col.id ?? idx} style={{ width: col.size }} className="rounded px-3 py-2">
                       <div className="h-4 w-full animate-pulse rounded bg-neutral-200" />
                     </td>
                   ))}
@@ -183,7 +180,7 @@ export function ScrollsTable({
                     <td
                       key={c.id}
                       style={{ width: c.column.getSize() }}
-                      className={`px-3 py-2 align-middle whitespace-nowrap ${c.column.columnDef.meta?.cellClassName ?? ''}`}
+                      className={`rounded px-3 py-2 align-middle whitespace-nowrap ${c.column.columnDef.meta?.cellClassName ?? ''}`}
                     >
                       {flexRender(c.column.columnDef.cell, c.getContext())}
                     </td>

--- a/app/shaolin-scrolls/_components/filters/Toolbar.tsx
+++ b/app/shaolin-scrolls/_components/filters/Toolbar.tsx
@@ -2,95 +2,53 @@
 
 import { FormEvent, useState } from 'react';
 import { useRouter } from 'next/navigation';
+import CreatePatchDialog from '../../CreatePatchDialog';
 
 interface ToolbarProps {
   search: string;
   onSearchChange: (value: string) => void;
 }
 
-type ReleaseType = 'patch' | 'minor';
-
 export default function Toolbar({ search, onSearchChange }: ToolbarProps) {
   const router = useRouter();
-
-  const [patchLabel, setPatchLabel] = useState('');
-  const [patchLoading, setPatchLoading] = useState(false);
-  const [patchError, setPatchError] = useState<string | null>(null);
-  const [patchCreated, setPatchCreated] = useState(false);
 
   const [minorLabel, setMinorLabel] = useState('');
   const [minorLoading, setMinorLoading] = useState(false);
   const [minorError, setMinorError] = useState<string | null>(null);
   const [minorCreated, setMinorCreated] = useState(false);
 
-  async function submit(e: FormEvent<HTMLFormElement>, type: ReleaseType) {
+  async function submit(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();
-    const isPatch = type === 'patch';
-    const label = (isPatch ? patchLabel : minorLabel).trim().slice(0, 120);
+    const label = minorLabel.trim().slice(0, 120);
     if (!label) return;
 
-    if (isPatch) {
-      setPatchLoading(true);
-      setPatchError(null);
-      setPatchCreated(false);
-    } else {
-      setMinorLoading(true);
-      setMinorError(null);
-      setMinorCreated(false);
-    }
+    setMinorLoading(true);
+    setMinorError(null);
+    setMinorCreated(false);
 
     try {
-      const res = await fetch(`/api/releases/${type}`, {
+      const res = await fetch('/api/releases/minor', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ label }),
       });
       if (!res.ok) throw new Error('Request failed');
-      if (isPatch) {
-        setPatchLabel('');
-        setPatchCreated(true);
-      } else {
-        setMinorLabel('');
-        setMinorCreated(true);
-      }
+      setMinorLabel('');
+      setMinorCreated(true);
       router.refresh();
     } catch {
-      if (isPatch) setPatchError('Failed to create patch release');
-      else setMinorError('Failed to create minor release');
+      setMinorError('Failed to create minor release');
     } finally {
-      if (isPatch) setPatchLoading(false);
-      else setMinorLoading(false);
+      setMinorLoading(false);
     }
   }
 
   return (
     <div className="flex flex-wrap items-center gap-2">
-      <div className="flex flex-col">
-        <form onSubmit={(e) => submit(e, 'patch')} className="flex items-center gap-2">
-          <input
-            id="patch-label"
-            aria-label="Patch label"
-            value={patchLabel}
-            onChange={(e) => setPatchLabel(e.target.value)}
-            maxLength={120}
-            placeholder="Patch label"
-            className="rounded border px-2 py-1"
-            required
-          />
-          <button
-            type="submit"
-            disabled={patchLoading}
-            className="rounded border px-3 py-1 disabled:opacity-50"
-          >
-            {patchLoading ? 'Creating…' : 'Create Patch'}
-          </button>
-        </form>
-        {patchError && <p className="text-xs text-red-600">{patchError}</p>}
-        {patchCreated && <p className="text-xs text-green-600">Created</p>}
-      </div>
+      <CreatePatchDialog onCreated={() => router.refresh()} />
 
       <div className="flex flex-col">
-        <form onSubmit={(e) => submit(e, 'minor')} className="flex items-center gap-2">
+        <form onSubmit={submit} className="flex items-center gap-2">
           <input
             id="minor-label"
             aria-label="Minor label"

--- a/components/CreateRelease.tsx
+++ b/components/CreateRelease.tsx
@@ -44,10 +44,13 @@ export default function CreateRelease() {
     }
 
     try {
+      const body = isPatch
+        ? { label, statusCode: "planned", releaseTypeCode: "hotfix" }
+        : { label };
       const res = await fetch(`/api/releases/${type}`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ label }),
+        body: JSON.stringify(body),
       });
 
       if (!res.ok) throw new Error("Request failed");

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+import { cn } from '@/lib/cn';
+
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: 'default' | 'outline';
+}
+
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant = 'default', ...props }, ref) => (
+    <button
+      ref={ref}
+      className={cn(
+        'inline-flex items-center justify-center rounded-md border px-3 py-2 text-sm font-medium disabled:opacity-50',
+        variant === 'outline' ? 'bg-transparent' : 'bg-neutral-100',
+        className
+      )}
+      {...props}
+    />
+  )
+);
+Button.displayName = 'Button';

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import { cn } from '@/lib/cn';
+
+export const Dialog = DialogPrimitive.Root;
+export const DialogTrigger = DialogPrimitive.Trigger;
+
+export function DialogContent({ className, ...props }: DialogPrimitive.DialogContentProps) {
+  return (
+    <DialogPrimitive.Portal>
+      <DialogPrimitive.Overlay className="fixed inset-0 bg-black/50" />
+      <DialogPrimitive.Content
+        className={cn(
+          'fixed left-1/2 top-1/2 w-11/12 max-w-md -translate-x-1/2 -translate-y-1/2 rounded-md bg-white p-4 shadow',
+          className
+        )}
+        {...props}
+      />
+    </DialogPrimitive.Portal>
+  );
+}
+
+export function DialogHeader({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn('mb-4', className)} {...props} />;
+}
+
+export const DialogTitle = DialogPrimitive.Title;

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import { cn } from '@/lib/cn';
+
+export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+export const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, ...props }, ref) => (
+    <input
+      ref={ref}
+      className={cn('flex h-9 w-full rounded-md border px-3 py-2 text-sm', className)}
+      {...props}
+    />
+  )
+);
+Input.displayName = 'Input';

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -1,0 +1,51 @@
+import * as React from 'react';
+import * as SelectPrimitive from '@radix-ui/react-select';
+import { cn } from '@/lib/cn';
+
+export const Select = SelectPrimitive.Root;
+
+export const SelectTrigger = React.forwardRef<
+  HTMLButtonElement,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Trigger
+    ref={ref}
+    className={cn('inline-flex w-full items-center justify-between rounded-md border px-3 py-2 text-sm', className)}
+    {...props}
+  />
+));
+SelectTrigger.displayName = SelectPrimitive.Trigger.displayName;
+
+export const SelectValue = SelectPrimitive.Value;
+
+export const SelectContent = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Portal>
+    <SelectPrimitive.Content
+      ref={ref}
+      className={cn('z-50 overflow-hidden rounded-md border bg-white shadow', className)}
+      {...props}
+    >
+      <SelectPrimitive.Viewport className="p-1">
+        {props.children}
+      </SelectPrimitive.Viewport>
+    </SelectPrimitive.Content>
+  </SelectPrimitive.Portal>
+));
+SelectContent.displayName = SelectPrimitive.Content.displayName;
+
+export const SelectItem = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Item
+    ref={ref}
+    className={cn('relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm focus:bg-neutral-100', className)}
+    {...props}
+  >
+    <SelectPrimitive.ItemText />
+  </SelectPrimitive.Item>
+));
+SelectItem.displayName = SelectPrimitive.Item.displayName;

--- a/db/migrations/002_fn_next_release_functions.sql
+++ b/db/migrations/002_fn_next_release_functions.sql
@@ -7,7 +7,7 @@
 -- Verification:
 --   psql $DATABASE_URL -f db/migrations/002_fn_next_release_functions.sql
 --   psql $DATABASE_URL -c "SELECT * FROM dojo.fn_next_minor('Test minor');"
---   psql $DATABASE_URL -c "SELECT * FROM dojo.fn_next_hotfix('Test hotfix');"
+--   psql $DATABASE_URL -c "SELECT * FROM dojo.fn_next_patch('Test hotfix', 'planned', 'hotfix');"
 
 CREATE OR REPLACE FUNCTION dojo.fn_next_patch(p_label TEXT)
 RETURNS TABLE(scroll_id BIGINT, generated_name TEXT)

--- a/db/migrations/004_fn_next_patch.sql
+++ b/db/migrations/004_fn_next_patch.sql
@@ -1,0 +1,84 @@
+-- 004_fn_next_patch.sql
+-- Purpose: add dojo.fn_next_patch(label, status_code, release_type_code) and retain legacy fn_next_hotfix(text)
+-- Verification:
+--   psql $DATABASE_URL -c "SELECT * FROM dojo.fn_next_patch('Example', 'planned', 'hotfix');"
+--   psql $DATABASE_URL -c "SELECT * FROM dojo.fn_next_hotfix('Example legacy');"
+
+-- Rename existing fn_next_patch(text) to fn_next_hotfix(text) if it exists
+ALTER FUNCTION IF EXISTS dojo.fn_next_patch(text)
+  RENAME TO fn_next_hotfix;
+
+-- Create new function with status and release_type parameters
+create or replace function dojo.fn_next_patch(
+  p_label text,
+  p_status_code text,
+  p_release_type_code text
+)
+returns table(scroll_id bigint, generated_name text)
+language plpgsql
+as
+$$
+declare
+  v_major int;
+  v_minor int;
+  v_patch int;
+  v_status_id smallint;
+  v_release_type_id smallint;
+begin
+  -- Resolve codes to ids (validate existence)
+  select rs.id into v_status_id
+    from dojo.release_status rs
+   where rs.code = p_status_code;
+  if v_status_id is null then
+    raise exception 'Unknown release_status code: %', p_status_code;
+  end if;
+
+  select rt.id into v_release_type_id
+    from dojo.release_type rt
+   where rt.code = p_release_type_code;
+  if v_release_type_id is null then
+    raise exception 'Unknown release_type code: %', p_release_type_code;
+  end if;
+
+  -- Latest released major/minor
+  select s.major, s.minor
+    into v_major, v_minor
+    from dojo.shaolin_scrolls s
+    join dojo.release_status rs on rs.id = s.release_status_id
+   where rs.code = 'released'
+   order by s.major desc, s.minor desc, s.patch desc
+   limit 1;
+
+  v_major := coalesce(v_major, 2);
+  v_minor := coalesce(v_minor, 0);
+
+  -- Next patch for that major/minor
+  select coalesce(max(s.patch), 0) + 1
+    into v_patch
+    from dojo.shaolin_scrolls s
+   where s.major = v_major
+     and s.minor = v_minor;
+
+  -- Insert new row
+  insert into dojo.shaolin_scrolls as ss
+    (major, minor, patch, year, month, label, release_status_id, release_type_id)
+  values (
+    v_major,
+    v_minor,
+    v_patch,
+    extract(year from current_date)::int,
+    extract(month from current_date)::int,
+    p_label,
+    v_status_id,
+    v_release_type_id
+  )
+  returning ss.id into scroll_id;
+
+  return query
+    select vs.id, vs.release_name::text as generated_name
+      from dojo.v_shaolin_scrolls vs
+     where vs.id = scroll_id;
+end;
+$$;
+
+alter function dojo.fn_next_patch(text, text, text) owner to tullyelly_admin;

--- a/db/migrations/005_drop_fn_next_hotfix.sql
+++ b/db/migrations/005_drop_fn_next_hotfix.sql
@@ -1,0 +1,6 @@
+-- 005_drop_fn_next_hotfix.sql
+-- Purpose: remove legacy dojo.fn_next_hotfix function after application code uses fn_next_patch.
+-- Verification:
+--   psql $DATABASE_URL -c "\df dojo.fn_next_hotfix"  # should show nothing
+
+drop function if exists dojo.fn_next_hotfix(text);

--- a/db/verification/002_fn_next_release.sql
+++ b/db/verification/002_fn_next_release.sql
@@ -1,11 +1,11 @@
 -- 002_fn_next_release.sql
--- Purpose: smoke-test fn_next_hotfix and fn_next_minor.
+-- Purpose: smoke-test fn_next_patch and fn_next_minor.
 -- Run with: psql $DATABASE_URL -f db/verification/002_fn_next_release.sql
 -- The transaction rolls back to avoid side effects.
 
 BEGIN;
 
--- Seed a released baseline required for fn_next_hotfix
+-- Seed a released baseline required for fn_next_patch
 INSERT INTO dojo.shaolin_scrolls
   (major, minor, patch, year, month, label, release_status_id, release_type_id)
 SELECT
@@ -16,8 +16,8 @@ SELECT
   (SELECT id FROM dojo.release_status WHERE code = 'released'),
   (SELECT id FROM dojo.release_type WHERE code = 'minor');
 
--- Next planned hotfix
-SELECT * FROM dojo.fn_next_patch('First hotfix');
+-- Next planned patch
+SELECT * FROM dojo.fn_next_patch('First hotfix', 'planned', 'hotfix');
 -- Expect: id plus generated_name like 'v2.0.1 First hotfix'
 
 -- Next planned minor release

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
       "hasInstallScript": true,
       "dependencies": {
         "@prisma/client": "^6.14.0",
+        "@radix-ui/react-dialog": "^1.1.1",
+        "@radix-ui/react-select": "^2.0.1",
         "@tanstack/react-table": "^8.21.3",
         "@tanstack/react-virtual": "^3.13.12",
         "next": "15.4.6",
@@ -1474,6 +1476,44 @@
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.3.tgz",
+      "integrity": "sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.4.tgz",
+      "integrity": "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.3",
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.6.tgz",
+      "integrity": "sha512-4JX6rEatQEvlmgU80wZyq9RT96HZJa88q8hp0pBd+LrczeDI4o6uA2M+uvxngVHo4Ihr8uibXxH6+70zhAFrVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.4"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
+      "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
+      "license": "MIT"
     },
     "node_modules/@fontsource-variable/inter": {
       "version": "5.2.6",
@@ -3072,6 +3112,562 @@
         "@prisma/debug": "6.14.0"
       }
     },
+    "node_modules/@radix-ui/number": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.1.tgz",
+      "integrity": "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-arrow": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.7.tgz",
+      "integrity": "sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collection": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.7.tgz",
+      "integrity": "sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.15.tgz",
+      "integrity": "sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-direction": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.1.tgz",
+      "integrity": "sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.11.tgz",
+      "integrity": "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-escape-keydown": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz",
+      "integrity": "sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.7.tgz",
+      "integrity": "sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-id": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.1.tgz",
+      "integrity": "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popper": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.8.tgz",
+      "integrity": "sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.0",
+        "@radix-ui/react-arrow": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-rect": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1",
+        "@radix-ui/rect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.9.tgz",
+      "integrity": "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
+      "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.2.6.tgz",
+      "integrity": "sha512-I30RydO+bnn2PQztvo25tswPH+wFBjehVGtmagkU78yMdwTwVf12wnAOF+AeP8S2N8xD+5UPbGhkUfPyvT+mwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.1",
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-visually-hidden": "1.2.3",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz",
+      "integrity": "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
+      "integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
+      "integrity": "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-escape-keydown": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.1.tgz",
+      "integrity": "sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
+      "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-previous": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.1.tgz",
+      "integrity": "sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-rect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.1.tgz",
+      "integrity": "sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/rect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.1.tgz",
+      "integrity": "sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-visually-hidden": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.3.tgz",
+      "integrity": "sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/rect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.1.tgz",
+      "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
+      "license": "MIT"
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -3779,7 +4375,7 @@
       "version": "19.1.10",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.10.tgz",
       "integrity": "sha512-EhBeSYX0Y6ye8pNebpKrwFJq7BoQ8J5SO6NlvNwwHjSj6adXJViPQrKlsyPw7hLBLvckEMO1yxeGdR82YBBlDg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -3789,7 +4385,7 @@
       "version": "19.1.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.7.tgz",
       "integrity": "sha512-i5ZzwYpqjmrKenzkoLM2Ibzt6mAsM7pxB6BCIouEVVmgiqaMj1TjaK7hnA36hbW5aZv20kx7Lw6hWzPWg0Rurw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.0.0"
@@ -4509,6 +5105,18 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/aria-hidden": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/aria-query": {
       "version": "5.3.0",
@@ -5399,7 +6007,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -5636,6 +6244,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+      "license": "MIT"
     },
     "node_modules/devlop": {
       "version": "1.1.0",
@@ -6991,6 +7605,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/get-package-type": {
@@ -11994,6 +12617,75 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/react-remove-scroll": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.1.tgz",
+      "integrity": "sha512-HpMh8+oahmIdOuS5aFKKY6Pyog+FNaZV/XyJOq7b4YFwsFHe5yYfdbIalI4k3vU2nSDql7YskmUseHsRrJqIPA==",
+      "license": "MIT",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.7",
+        "react-style-singleton": "^2.2.3",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.3",
+        "use-sidecar": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-remove-scroll-bar": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+      "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-style-singleton": "^2.2.2",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-style-singleton": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+      "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-nonce": "^1.0.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/readdirp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
@@ -13750,6 +14442,49 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-callback-ref": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/v8-to-istanbul": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,8 @@
     "pg": "^8.16.3",
     "react": "19.1.0",
     "react-dom": "19.1.0",
+    "@radix-ui/react-dialog": "^1.1.1",
+    "@radix-ui/react-select": "^2.0.1",
     "sharp": "^0.34.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "test:e2e:headed": "cross-env PLAYWRIGHT_BROWSERS_PATH=.pw-browsers npx playwright test --headed",
     "test:e2e:install": "cross-env PLAYWRIGHT_BROWSERS_PATH=.pw-browsers npx playwright install --with-deps",
     "test:e2e:ci": "cross-env PLAYWRIGHT_BROWSERS_PATH=.pw-browsers npx playwright test --reporter=html",
-    "db:ping": "DOTENV_CONFIG_PATH=.env.local tsx -r dotenv/config scripts/db-ping.ts"
+    "db:ping": "DOTENV_CONFIG_PATH=.env.local tsx -r dotenv/config scripts/db-ping.ts",
+    "verify:deps": "npm ls @radix-ui/react-dialog @radix-ui/react-select @floating-ui/react-dom >/dev/null"
   },
   "dependencies": {
     "@prisma/client": "^6.14.0",


### PR DESCRIPTION
## Summary
- add fn_next_patch(label, status_code, release_type_code) and cleanup migration
- expose release status/type meta APIs and patch creation endpoint
- replace patch form with dialog, polish scroll table styling

## Testing
- `npm test` *(fails: Missing env var: TEST_DATABASE_URL)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68afb1d9f23c832e842d230cc1bf0bf3