### PR TITLE
Refactor Shaolin Scrolls table layout and badges

### DIFF
--- a/app/heels-have-eyes/page.tsx
+++ b/app/heels-have-eyes/page.tsx
@@ -122,7 +122,7 @@ export default function Page() {
                     </p>
                   )}
                   {isFav(item) && (
-                    <Badge tone="success" className="absolute bottom-2 right-2">
+                    <Badge intent="released" className="absolute bottom-2 right-2">
                       unclejimmy classic
                     </Badge>
                   )}

--- a/app/roadwork-rappin/page.tsx
+++ b/app/roadwork-rappin/page.tsx
@@ -125,7 +125,7 @@ export default function Page() {
                     </p>
                   )}
                   {isFav(item) && (
-                    <Badge tone="success" className="absolute bottom-2 right-2">
+                    <Badge intent="released" className="absolute bottom-2 right-2">
                       unclejimmy classic
                     </Badge>
                   )}

--- a/app/shaolin-scrolls/_components/ScrollsPageClient.tsx
+++ b/app/shaolin-scrolls/_components/ScrollsPageClient.tsx
@@ -8,11 +8,9 @@ import Toolbar from './filters/Toolbar';
 export default function ScrollsPageClient({ data }: { data: Release[] }) {
   const [search, setSearch] = useState('');
   return (
-    <div className="flex flex-col h-full gap-3">
+    <div className="flex flex-col gap-3">
       <Toolbar search={search} onSearchChange={setSearch} />
-      <div className="flex-1 min-h-0">
-        <ScrollsTable data={data} globalFilter={search} />
-      </div>
+      <ScrollsTable data={data} globalFilter={search} />
     </div>
   );
 }

--- a/app/shaolin-scrolls/_components/ScrollsTable.tsx
+++ b/app/shaolin-scrolls/_components/ScrollsTable.tsx
@@ -11,7 +11,7 @@ import {
   useReactTable,
   type RowData,
 } from '@tanstack/react-table';
-import { Badge } from '@/components/ui/Badge';
+import { Badge, type BadgeIntent } from '@/components/ui/Badge';
 
 declare module '@tanstack/react-table' {
   interface ColumnMeta<TData extends RowData, TValue> {
@@ -28,6 +28,17 @@ export type Release = {
   type: 'planned' | 'patch' | 'minor' | 'hotfix';
   semver: string;
 };
+
+const toIntent = (value?: string): BadgeIntent => {
+  const v = (value ?? '').toLowerCase()
+  if (v === 'planned') return 'planned'
+  if (v === 'released') return 'released'
+  if (v === 'minor') return 'minor'
+  if (v === 'hotfix') return 'hotfix'
+  if (v === 'archived') return 'archived'
+  if (v === 'patch') return 'patch'
+  return 'neutral'
+}
 
 const columns: ColumnDef<Release, any>[] = [
   {
@@ -46,8 +57,8 @@ const columns: ColumnDef<Release, any>[] = [
     header: 'Status',
     size: 120,
     cell: info => {
-      const v = info.getValue<Release['status']>();
-      return <Badge intent={v}>{v}</Badge>;
+      const v = info.getValue<Release['status']>()
+      return <Badge intent={toIntent(v)}>{v}</Badge>
     },
     meta: { headerClassName: 'text-left w-[120px]', cellClassName: 'text-left w-[120px] shrink-0' },
   },
@@ -56,8 +67,8 @@ const columns: ColumnDef<Release, any>[] = [
     header: 'Type',
     size: 100,
     cell: info => {
-      const v = info.getValue<Release['type']>();
-      return <Badge intent={v}>{v}</Badge>;
+      const v = info.getValue<Release['type']>()
+      return <Badge intent={toIntent(v)}>{v}</Badge>
     },
     meta: { headerClassName: 'text-left w-[100px]', cellClassName: 'text-left w-[100px] shrink-0' },
   },

--- a/app/shaolin-scrolls/_components/ScrollsTable.tsx
+++ b/app/shaolin-scrolls/_components/ScrollsTable.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useMemo } from 'react';
 import {
   ColumnDef,
   flexRender,
@@ -11,6 +11,7 @@ import {
   useReactTable,
   type RowData,
 } from '@tanstack/react-table';
+import { Badge } from '@/components/ui/Badge';
 
 declare module '@tanstack/react-table' {
   interface ColumnMeta<TData extends RowData, TValue> {
@@ -24,20 +25,8 @@ export type Release = {
   name: string;
   plannedDate: string;
   status: 'planned' | 'released' | 'archived';
-  type: 'patch' | 'minor' | 'hotfix';
+  type: 'planned' | 'patch' | 'minor' | 'hotfix';
   semver: string;
-};
-
-const STATUS_STYLES: Record<Release['status'], string> = {
-  planned: 'bg-[#0077C0] text-white',
-  released: 'bg-[#008000] text-white',
-  archived: 'bg-[#EEE1C6] text-black',
-};
-
-const TYPE_STYLES: Record<Release['type'], string> = {
-  patch: 'bg-[#F0EBD2] text-black',
-  minor: 'bg-[#008000] text-white',
-  hotfix: 'bg-[#C41E3A] text-white',
 };
 
 const columns: ColumnDef<Release, any>[] = [
@@ -58,11 +47,7 @@ const columns: ColumnDef<Release, any>[] = [
     size: 120,
     cell: info => {
       const v = info.getValue<Release['status']>();
-      return (
-        <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${STATUS_STYLES[v]}`}>
-          {v}
-        </span>
-      );
+      return <Badge intent={v}>{v}</Badge>;
     },
     meta: { headerClassName: 'text-left w-[120px]', cellClassName: 'text-left w-[120px] shrink-0' },
   },
@@ -72,11 +57,7 @@ const columns: ColumnDef<Release, any>[] = [
     size: 100,
     cell: info => {
       const v = info.getValue<Release['type']>();
-      return (
-        <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${TYPE_STYLES[v]}`}>
-          {v}
-        </span>
-      );
+      return <Badge intent={v}>{v}</Badge>;
     },
     meta: { headerClassName: 'text-left w-[100px]', cellClassName: 'text-left w-[100px] shrink-0' },
   },
@@ -101,17 +82,7 @@ export function ScrollsTable({
   pageSize?: number;
   isLoading?: boolean;
 }) {
-  const [scrolled, setScrolled] = useState(false);
-  const containerRef = useRef<HTMLDivElement>(null);
   const memoData = useMemo(() => data, [data]);
-
-  useEffect(() => {
-    const el = containerRef.current;
-    if (!el) return;
-    const onScroll = () => setScrolled(el.scrollTop > 0);
-    el.addEventListener('scroll', onScroll);
-    return () => el.removeEventListener('scroll', onScroll);
-  }, []);
 
   const table = useReactTable({
     data: memoData,
@@ -129,18 +100,18 @@ export function ScrollsTable({
   const BUILD = process.env.VERCEL_GIT_COMMIT_SHA || 'local';
 
   return (
-    <div id="scrolls-table" data-build={BUILD} className="flex h-full flex-col">
+    <div id="scrolls-table" data-build={BUILD} className="flex flex-col">
       <div className="mb-2 text-xs text-neutral-500">Build: {BUILD}</div>
-      <div ref={containerRef} className="flex-1 min-h-0 rounded-xl border overflow-auto">
-        <table className="table-fixed w-full border-separate border-spacing-0">
-          <thead className={`sticky top-0 bg-white ${scrolled ? 'shadow-sm' : ''}`}>
+      <div className="overflow-x-auto rounded-xl border border-gray-200 bg-white p-4 md:p-6 shadow-sm">
+        <table className="min-w-full table-auto">
+          <thead className="bg-gray-50 sticky top-0 z-10">
             {table.getHeaderGroups().map(hg => (
               <tr key={hg.id}>
                 {hg.headers.map(h => (
                   <th
                     key={h.id}
                     style={{ width: h.getSize() }}
-                    className={`px-3 py-2 text-xs font-semibold uppercase tracking-wide align-middle ${h.column.columnDef.meta?.headerClassName ?? ''}`}
+                    className={`px-4 py-3 text-left text-sm font-medium text-gray-700 ${h.column.columnDef.meta?.headerClassName ?? ''}`}
                   >
                     {h.isPlaceholder ? null : (
                       <button
@@ -165,12 +136,12 @@ export function ScrollsTable({
               </tr>
             ))}
           </thead>
-          <tbody>
+          <tbody className="divide-y divide-gray-100">
             {isLoading ? (
               Array.from({ length: pageSize }).map((_, i) => (
-                <tr key={i} className="odd:bg-neutral-50">
+                <tr key={i} className="hover:bg-gray-50">
                   {columns.map((col, idx) => (
-                    <td key={col.id ?? idx} style={{ width: col.size }} className="px-3 py-2">
+                    <td key={col.id ?? idx} style={{ width: col.size }} className="px-4 py-3">
                       <div className="h-4 w-full animate-pulse rounded bg-neutral-200" />
                     </td>
                   ))}
@@ -178,12 +149,12 @@ export function ScrollsTable({
               ))
             ) : table.getRowModel().rows.length ? (
               table.getRowModel().rows.map(r => (
-                <tr key={r.id} className="odd:bg-neutral-50 hover:bg-neutral-100">
+                <tr key={r.id} className="hover:bg-gray-50">
                   {r.getVisibleCells().map(c => (
                     <td
                       key={c.id}
                       style={{ width: c.column.getSize() }}
-                      className={`px-3 py-2 align-middle whitespace-nowrap ${c.column.columnDef.meta?.cellClassName ?? ''}`}
+                      className={`px-4 py-3 text-sm text-gray-800 align-middle whitespace-nowrap ${c.column.columnDef.meta?.cellClassName ?? ''}`}
                     >
                       {flexRender(c.column.columnDef.cell, c.getContext())}
                     </td>

--- a/app/shaolin-scrolls/page.tsx
+++ b/app/shaolin-scrolls/page.tsx
@@ -65,16 +65,14 @@ export default async function Page({ searchParams }: PageProps) {
   }));
 
   return (
-    <section className="flex h-[calc(100vh-160px)] flex-col gap-4">
+    <section className="flex min-h-screen flex-col gap-4">
       <h1 className="text-xl font-semibold">Shaolin Scrolls</h1>
       {error && (
         <div role="alert" className="rounded border border-red-500 bg-red-50 p-2 text-sm text-red-600">
           {error}
         </div>
       )}
-      <div className="flex-1 min-h-0">
-        <ScrollsPageClient data={releases} />
-      </div>
+      <ScrollsPageClient data={releases} />
     </section>
   );
 }

--- a/components/ui/Badge.tsx
+++ b/components/ui/Badge.tsx
@@ -1,31 +1,27 @@
-import React from 'react'
+'use client'
+
+import * as React from 'react'
 import { cn } from '@/lib/cn'
 
-export type BadgeProps = {
-  intent?: 'planned' | 'released' | 'minor' | 'hotfix' | 'archived' | 'patch'
-  tone?: 'neutral' | 'success' | 'warning'
-  className?: string
+export type BadgeIntent =
+  | 'planned'
+  | 'released'
+  | 'minor'
+  | 'hotfix'
+  | 'archived'
+  | 'patch'
+  | 'neutral'
+
+interface BadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
+  intent?: BadgeIntent
   children: React.ReactNode
 }
 
-export function Badge({ intent, tone = 'neutral', className, children, ...props }: BadgeProps) {
-  if (intent) {
-    return (
-      <span className={cn('badge', `badge--${intent}`, className)} {...props}>
-        {children}
-      </span>
-    )
-  }
-
-  const base = 'inline-flex items-center rounded-full px-2 py-0.5 text-[11px] leading-4 font-medium'
-  const tones = {
-    neutral: 'border border-border text-fg/80',
-    success: 'bg-[var(--success)] text-white',
-    warning: 'bg-warning/10 text-warning ring-1 ring-warning/20',
-  }
+export function Badge({ intent = 'neutral', className, children, ...props }: BadgeProps) {
   return (
-    <span className={cn(base, tones[tone], className)} {...props}>
+    <span className={cn('badge', `badge--${intent}`, className)} {...props}>
       {children}
     </span>
   )
 }
+

--- a/components/ui/Badge.tsx
+++ b/components/ui/Badge.tsx
@@ -2,17 +2,30 @@ import React from 'react'
 import { cn } from '@/lib/cn'
 
 export type BadgeProps = {
+  intent?: 'planned' | 'released' | 'minor' | 'hotfix' | 'archived' | 'patch'
   tone?: 'neutral' | 'success' | 'warning'
   className?: string
   children: React.ReactNode
 }
 
-export function Badge({ tone = 'neutral', className, children }: BadgeProps) {
+export function Badge({ intent, tone = 'neutral', className, children, ...props }: BadgeProps) {
+  if (intent) {
+    return (
+      <span className={cn('badge', `badge--${intent}`, className)} {...props}>
+        {children}
+      </span>
+    )
+  }
+
   const base = 'inline-flex items-center rounded-full px-2 py-0.5 text-[11px] leading-4 font-medium'
   const tones = {
     neutral: 'border border-border text-fg/80',
     success: 'bg-[var(--success)] text-white',
     warning: 'bg-warning/10 text-warning ring-1 ring-warning/20',
   }
-  return <span className={cn(base, tones[tone], className)}>{children}</span>
+  return (
+    <span className={cn(base, tones[tone], className)} {...props}>
+      {children}
+    </span>
+  )
 }

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -101,6 +101,7 @@ export default {
         '.badge--hotfix': { backgroundColor: theme('colors.badge.hotfix'), color: '#fff' },
         '.badge--archived': { backgroundColor: theme('colors.badge.archived'), color: '#111827' },
         '.badge--patch': { backgroundColor: theme('colors.badge.patch'), color: '#111827' },
+        '.badge--neutral': { backgroundColor: theme('colors.badge.neutral'), color: '#fff' },
       })
     }),
   ],

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -1,4 +1,6 @@
 // Tailwind v4 — ESM config
+import plugin from 'tailwindcss/plugin'
+
 export default {
   content: [
     "./app/**/*.{js,jsx,ts,tsx,mdx}",
@@ -33,12 +35,30 @@ export default {
         fg: "var(--fg)",
         success: "var(--success)",
         warning: "var(--warning)",
+        brand: {
+          bucksGreen: '#00471B',
+          creamCityCream: '#EEE1C6',
+          greatLakesBlue: '#0077C0',
+          championshipGold: '#F0EBD2',
+          red: '#C8102E',
+          border: 'var(--border, #e5e7eb)',
+          card: 'var(--card, #ffffff)',
+        },
+        badge: {
+          planned: 'var(--badge-planned, #0077C0)',
+          released: 'var(--badge-released, #16a34a)',
+          minor: 'var(--badge-minor, #16a34a)',
+          hotfix: 'var(--badge-hotfix, #C8102E)',
+          archived: 'var(--badge-archived, #E9D8C7)',
+          patch: 'var(--badge-patch, #F0EBD2)',
+          neutral: 'var(--badge-neutral, #64748b)',
+        },
       },
       maxWidth: {
         container: "var(--container)",
       },
       fontFamily: {
-        sans: [
+      sans: [
           "var(--font-inter)",
           "system-ui",
           "-apple-system",
@@ -57,7 +77,31 @@ export default {
           "monospace",
         ],
       },
+      borderRadius: {
+        badge: '9999px',
+      },
     },
   },
-  plugins: [],
+  plugins: [
+    plugin(function ({ addComponents, theme }) {
+      addComponents({
+        '.badge': {
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: '0.375rem',
+          padding: '0.25rem 0.5rem',
+          borderRadius: theme('borderRadius.badge'),
+          fontSize: '0.875rem',
+          fontWeight: '600',
+          lineHeight: '1.25rem',
+        },
+        '.badge--planned': { backgroundColor: theme('colors.badge.planned'), color: '#fff' },
+        '.badge--released': { backgroundColor: theme('colors.badge.released'), color: '#fff' },
+        '.badge--minor': { backgroundColor: theme('colors.badge.minor'), color: '#fff' },
+        '.badge--hotfix': { backgroundColor: theme('colors.badge.hotfix'), color: '#fff' },
+        '.badge--archived': { backgroundColor: theme('colors.badge.archived'), color: '#111827' },
+        '.badge--patch': { backgroundColor: theme('colors.badge.patch'), color: '#111827' },
+      })
+    }),
+  ],
 };


### PR DESCRIPTION
## Summary
- move vertical scrolling to page and wrap releases table in padded card
- introduce reusable badge tokens and component for status and type
- lighten table styling with roomier spacing and softer borders

## Testing
- `TEST_DATABASE_URL=postgres://user:pass@localhost:5432/db npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68afc5234ef4832eb7ff0e56c3b8c768