### PR TITLE
feat: tweak release table visuals

### DIFF
--- a/app/shaolin-scrolls/_components/ScrollsTable.tsx
+++ b/app/shaolin-scrolls/_components/ScrollsTable.tsx
@@ -109,7 +109,7 @@ export function ScrollsTable({
       <div className="mb-2 text-xs text-neutral-500">Build: {BUILD}</div>
       <div className="overflow-x-auto rounded-xl border border-gray-200 bg-white p-4 md:p-6 shadow-sm">
         <table className="min-w-full table-auto">
-          <thead className="bg-[#F0EBD2] text-[#00471B] sticky top-0 z-10">
+          <thead className="bg-[#00471B] text-[#EEE1C6] sticky top-0 z-10">
             {table.getHeaderGroups().map(hg => (
               <tr key={hg.id}>
                 {hg.headers.map(h => (

--- a/app/shaolin-scrolls/_components/ScrollsTable.tsx
+++ b/app/shaolin-scrolls/_components/ScrollsTable.tsx
@@ -109,14 +109,14 @@ export function ScrollsTable({
       <div className="mb-2 text-xs text-neutral-500">Build: {BUILD}</div>
       <div className="overflow-x-auto rounded-xl border border-gray-200 bg-white p-4 md:p-6 shadow-sm">
         <table className="min-w-full table-auto">
-          <thead className="bg-gray-50 sticky top-0 z-10">
+          <thead className="bg-[#F0EBD2] text-[#00471B] sticky top-0 z-10">
             {table.getHeaderGroups().map(hg => (
               <tr key={hg.id}>
                 {hg.headers.map(h => (
                   <th
                     key={h.id}
                     style={{ width: h.getSize() }}
-                    className={`px-4 py-3 text-left text-sm font-medium text-gray-700 ${h.column.columnDef.meta?.headerClassName ?? ''}`}
+                    className={`px-4 py-3 text-left text-sm font-medium ${h.column.columnDef.meta?.headerClassName ?? ''}`}
                   >
                     {h.isPlaceholder ? null : (
                       <button
@@ -144,7 +144,7 @@ export function ScrollsTable({
           <tbody className="divide-y divide-gray-100">
             {isLoading ? (
               Array.from({ length: pageSize }).map((_, i) => (
-                <tr key={i} className="hover:bg-gray-50">
+                <tr key={i} className="odd:bg-white even:bg-[#EEE1C6] hover:bg-[#0077C0]/10">
                   {columns.map((col, idx) => (
                     <td key={col.id ?? idx} style={{ width: col.size }} className="px-4 py-3">
                       <div className="h-4 w-full animate-pulse rounded bg-neutral-200" />
@@ -154,7 +154,7 @@ export function ScrollsTable({
               ))
             ) : table.getRowModel().rows.length ? (
               table.getRowModel().rows.map(r => (
-                <tr key={r.id} className="hover:bg-gray-50">
+                <tr key={r.id} className="odd:bg-white even:bg-[#EEE1C6] hover:bg-[#0077C0]/10">
                   {r.getVisibleCells().map(c => (
                     <td
                       key={c.id}
@@ -167,7 +167,7 @@ export function ScrollsTable({
                 </tr>
               ))
             ) : (
-              <tr>
+              <tr className="odd:bg-white even:bg-[#EEE1C6] hover:bg-[#0077C0]/10">
                 <td colSpan={columnCount} className="p-4 text-center text-sm">
                   No releases found
                 </td>


### PR DESCRIPTION
## Summary
- restyle release table header for improved contrast
- add alternating row colors and subtle hover styling

## Testing
- `npm run lint`
- `TEST_DATABASE_URL=postgres://user:pass@localhost:5432/test npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b00a064b98832e93c7344b5318da0f