### PR TITLE
[WU-000] Add hydration guardrails

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,9 +1,13 @@
 {
   "root": true,
-  "extends": ["next/core-web-vitals"],
+  "extends": [
+    "next/core-web-vitals"
+  ],
   "overrides": [
     {
-      "files": ["**/*.tsx"],
+      "files": [
+        "**/*.tsx"
+      ],
       "rules": {
         "no-restricted-syntax": [
           "error",
@@ -22,8 +26,13 @@
           {
             "selector": "UnaryExpression[operator='typeof'][argument.name='window']",
             "message": "Avoid typeof window checks in React components."
+          },
+          {
+            "selector": "CallExpression[callee.property.name=/toLocale(?:DateString|String|TimeString)?/]",
+            "message": "Use formatDateDisplay from lib/format.ts instead of toLocaleString."
           }
-        ]
+        ],
+        "react/no-array-index-key": "error"
       }
     }
   ]

--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Recommended Node version: **20**.
 * `npm run typecheck` – run TypeScript checks
 * `npm run build` – build the production bundle
 * `npm run start` – start the production server
+* `npm run start:prod` – build and serve the production bundle on port 4010
 * `npm run ci` – run lint, image checks, and build
 * `npm run db:ping` – verify DB connectivity (SELECT 1)
 * `npm run check:use-server` – flag invalid `"use server"` exports

--- a/app/shaolin-scrolls/_components/ScrollsTable.tsx
+++ b/app/shaolin-scrolls/_components/ScrollsTable.tsx
@@ -33,6 +33,7 @@ export type Release = {
 const columns: ColumnDef<Release, any>[] = [
   {
     accessorKey: 'name',
+    id: 'name',
     header: 'Release Name',
     minSize: 320,
     cell: info => (
@@ -44,6 +45,7 @@ const columns: ColumnDef<Release, any>[] = [
   },
   {
     accessorKey: 'status',
+    id: 'status',
     header: 'Status',
     size: 120,
     cell: info => {
@@ -56,6 +58,7 @@ const columns: ColumnDef<Release, any>[] = [
   },
   {
     accessorKey: 'type',
+    id: 'type',
     header: 'Type',
     size: 100,
     cell: info => {
@@ -68,6 +71,7 @@ const columns: ColumnDef<Release, any>[] = [
   },
   {
     accessorKey: 'semver',
+    id: 'semver',
     header: 'SemVer',
     size: 96,
     cell: info => <code className="font-mono tabular-nums">{info.getValue<string>()}</code>,
@@ -93,6 +97,7 @@ export function ScrollsTable({
     data: memoData,
     columns,
     state: { globalFilter },
+    getRowId: row => row.id,
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
@@ -143,10 +148,10 @@ export function ScrollsTable({
           </thead>
           <tbody className="divide-y divide-gray-100">
             {isLoading ? (
-              Array.from({ length: pageSize }).map((_, i) => (
-                <tr key={i} className="odd:bg-white even:bg-[#EEE1C6] hover:bg-[#0077C0]/10">
-                  {columns.map((col, idx) => (
-                    <td key={col.id ?? idx} style={{ width: col.size }} className="px-4 py-3">
+              Array.from({ length: pageSize }, (_, i) => `skeleton-${i}`).map(key => (
+                <tr key={key} className="odd:bg-white even:bg-[#EEE1C6] hover:bg-[#0077C0]/10">
+                  {columns.map(col => (
+                    <td key={col.id} style={{ width: col.size }} className="px-4 py-3">
                       <div className="h-4 w-full animate-pulse rounded bg-neutral-200" />
                     </td>
                   ))}

--- a/docs/hydration.md
+++ b/docs/hydration.md
@@ -7,4 +7,10 @@ Dynamic pages fetch data on the server and pass a serialized snapshot to client 
 - Date objects are converted to ISO strings before being sent to the client.
 - Client components render the snapshot and avoid automatic re-fetching on mount.
 
+## Guardrails
+
+- `npm run start:prod` builds and serves the production bundle locally.
+- Playwright test `shaolin-scrolls.spec.ts` fails on any console hydration mismatch.
+- ESLint bans `toLocaleString`, `Date.now`, `Math.random`, and array index keys in `.tsx` files.
+
 This keeps the server-rendered HTML identical to the first client render and eliminates hydration warnings.

--- a/e2e/shaolin-scrolls.spec.ts
+++ b/e2e/shaolin-scrolls.spec.ts
@@ -1,7 +1,34 @@
 import { test, expect } from './fixtures';
 
-test('Shaolin Scrolls page hydrates without errors', async ({ page }) => {
+// ensure no hydration warnings across table interactions
+// relies on prod-like build when E2E_PROD=1
+
+test('Shaolin Scrolls table hydrates without warnings', async ({ page }) => {
+  const hydrationErrors: string[] = [];
+  page.on('console', msg => {
+    const type = msg.type();
+    if ((type === 'warning' || type === 'error') && msg.text().includes('Hydration failed')) {
+      hydrationErrors.push(msg.text());
+    }
+  });
+
   await page.goto('/shaolin-scrolls');
   await expect(page.locator('h1')).toHaveText('Shaolin Scrolls');
   await expect(page.locator('#scrolls-table')).toBeVisible();
+
+  // sort ascending then descending
+  const firstHeader = page.locator('thead th button').first();
+  await firstHeader.click();
+  await firstHeader.click();
+
+  // paginate next then previous
+  await page.locator('button[aria-label="Next page"]').click();
+  await page.locator('button[aria-label="Previous page"]').click();
+
+  // search and clear
+  const search = page.locator('input[aria-label="Search releases"]');
+  await search.fill('Release 1');
+  await search.fill('');
+
+  expect(hydrationErrors).toHaveLength(0);
 });

--- a/lib/format.ts
+++ b/lib/format.ts
@@ -1,0 +1,18 @@
+export const ISO_TZ = 'UTC';
+
+export function formatDateISO(d: string | Date): string {
+  const date = typeof d === 'string' ? new Date(d) : d;
+  return date.toISOString();
+}
+
+export function formatDateDisplay(d: string | Date): string {
+  const date = typeof d === 'string' ? new Date(d) : d;
+  return new Intl.DateTimeFormat('en-US', {
+    timeZone: 'UTC',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(date);
+}

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "postinstall": "prisma generate",
     "build": "prisma generate && next build",
     "start": "next start",
+    "start:prod": "npm run build && NODE_ENV=production PORT=4010 npm start",
     "lint": "next lint",
     "images:optimize": "node scripts/optimize-images.mjs",
     "images:check": "node scripts/check-images.mjs",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,11 +1,15 @@
 import { defineConfig, devices } from '@playwright/test';
 
+const isProd = process.env.E2E_PROD === '1';
+const port = isProd ? 4010 : 3000;
+const command = isProd ? 'npm run start:prod' : 'npm run dev -- -p 3000';
+
 export default defineConfig({
   testDir: 'e2e',
   reporter: [['html', { outputFolder: 'playwright-report' }]],
   retries: 1,
   use: {
-    baseURL: 'http://localhost:3000',
+    baseURL: `http://localhost:${port}`,
     trace: 'on-first-retry',
   },
   projects: [
@@ -24,8 +28,8 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: 'npm run dev -- -p 3000',
-    port: 3000,
+    command,
+    port,
     reuseExistingServer: !process.env.CI,
     timeout: 120 * 1000,
     env: {


### PR DESCRIPTION
## Summary
- add start:prod script and production-aware Playwright config
- harden ScrollsTable keys and add hydration warning e2e test
- enforce deterministic rendering via ESLint rules and format helpers

## Testing
- `npm run lint`
- `npm run typecheck`
- `TEST_DATABASE_URL=postgres://localhost:5432/placeholder npm test`
- `E2E_PROD=1 npm run test:e2e` *(fails: ECONNREFUSED connecting to Postgres)*

------
https://chatgpt.com/codex/tasks/task_e_68b33f4daa7c832eb0635d3a7d1c264c