### PR TITLE
[WU-000] add shout out component and lab

### DIFF
--- a/__tests__/shout-out.test.tsx
+++ b/__tests__/shout-out.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react'
+import { axe } from 'jest-axe'
+import ShoutOut from '@/components/shout-out'
+
+test('renders inline by default', () => {
+  render(<p>hi <ShoutOut>hello</ShoutOut> there</p>)
+  const el = screen.getByText('hello').closest('span')
+  expect(el?.tagName).toBe('SPAN')
+})
+
+test('respects variant/as/icon props', () => {
+  render(
+    <ShoutOut as="div" variant="note" icon="sprout">
+      hello
+    </ShoutOut>
+  )
+  const el = screen.getByRole('note')
+  expect(el.tagName).toBe('DIV')
+  expect(el).toHaveAttribute('data-variant', 'note')
+  expect(el.querySelector('svg')).toBeTruthy()
+})
+
+test('a11y attributes present', async () => {
+  const { container } = render(<ShoutOut>hi</ShoutOut>)
+  const el = screen.getByRole('note')
+  expect(el).toHaveAttribute('aria-label', 'Shout out')
+  expect(await axe(container)).toHaveNoViolations()
+})

--- a/app/globals.css
+++ b/app/globals.css
@@ -31,6 +31,9 @@
   --text-primary: var(--black);
   --text-on-blue: var(--white);
   --text-on-green: var(--white);
+  /* ShoutOut defaults */
+  --so-accent: hsl(var(--muted-foreground));
+  --so-bg: color-mix(in oklab, currentColor 6%, transparent);
 
   /* Links */
   --link-on-white: var(--blue);
@@ -250,6 +253,35 @@ p {
   overflow: hidden;
   clip: rect(1px, 1px, 1px, 1px);
   white-space: nowrap;
+}
+
+/* ShoutOut component */
+.so-inline {
+  --_so-underline: color-mix(in oklab, currentColor 30%, transparent);
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.25rem;
+  padding-left: 0.5rem;
+  border-left: 1px solid var(--so-accent);
+} 
+.so-inline .so-icon {
+  width: 0.9em;
+  height: 0.9em;
+  color: var(--so-accent);
+}
+.so-inline[data-variant='note'] {
+  border-left-style: dotted;
+  background-color: var(--so-bg);
+  border-radius: 0.125rem;
+}
+.so-inline[data-variant='spark'] {
+  border-left-width: 0;
+  padding-left: 0;
+  border-bottom: 1px dotted var(--_so-underline);
+} 
+.so-inline[data-variant='spark']:hover,
+.so-inline[data-variant='spark']:focus {
+  border-bottom-color: currentColor;
 }
 
 

--- a/app/ui-lab/DemoLab.tsx
+++ b/app/ui-lab/DemoLab.tsx
@@ -49,6 +49,10 @@ export default function DemoLab() {
     <div className="mx-auto max-w-container space-y-8 p-4">
       <h1 className="text-4xl font-extrabold">UI Lab</h1>
       <div className="grid gap-6 md:grid-cols-2">
+        <section className="card space-y-4" aria-labelledby="shout-out">
+          <h2 id="shout-out" className="text-xl font-semibold">Shout Out</h2>
+          <p><a href="/ui-lab/shout-out" className="underline hover:no-underline">Open Shout Out lab</a></p>
+        </section>
         <section className="card space-y-4" aria-labelledby="announcement-banner">
           <h2 id="announcement-banner" className="text-xl font-semibold">Announcement Banner</h2>
           <div className="space-y-4">

--- a/app/ui-lab/shout-out/ShoutOutLab.tsx
+++ b/app/ui-lab/shout-out/ShoutOutLab.tsx
@@ -1,0 +1,131 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import ShoutOut from '@/components/shout-out'
+
+function parseRgb(input: string): [number, number, number] {
+  const m = input.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)/)
+  if (!m) return [0, 0, 0]
+  return [parseInt(m[1], 10), parseInt(m[2], 10), parseInt(m[3], 10)]
+}
+
+function luminance([r, g, b]: [number, number, number]) {
+  const a = [r, g, b].map(v => {
+    v /= 255
+    return v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4)
+  })
+  return 0.2126 * a[0] + 0.7152 * a[1] + 0.0722 * a[2]
+}
+
+export default function ShoutOutLab() {
+  const [variant, setVariant] = useState<'whisper' | 'note' | 'spark'>('whisper')
+  const [asEl, setAsEl] = useState<'span' | 'div'>('span')
+  const [icon, setIcon] = useState<'none' | 'star' | 'sprout' | 'quill'>('star')
+  const [density, setDensity] = useState<'compact' | 'comfy'>('compact')
+  const [tone, setTone] = useState<'neutral' | 'brand' | 'accent'>('neutral')
+  const ref = useRef<HTMLSpanElement | HTMLDivElement>(null)
+  const [contrast, setContrast] = useState('')
+
+  useEffect(() => {
+    const el = ref.current
+    if (!el) return
+    const styles = getComputedStyle(el)
+    const fg = parseRgb(styles.color)
+    const bgString = styles.backgroundColor === 'rgba(0, 0, 0, 0)' ? getComputedStyle(document.body).backgroundColor : styles.backgroundColor
+    const bg = parseRgb(bgString)
+    const l1 = luminance(fg)
+    const l2 = luminance(bg)
+    const ratio = l1 > l2 ? (l1 + 0.05) / (l2 + 0.05) : (l2 + 0.05) / (l1 + 0.05)
+    setContrast(ratio.toFixed(2))
+  }, [variant, asEl, icon, density, tone])
+
+  const toneStyle = tone === 'brand'
+    ? { '--so-accent': 'var(--blue)' }
+    : tone === 'accent'
+      ? { '--so-accent': 'var(--green)' }
+      : undefined
+
+  const densityClass = density === 'comfy' && asEl === 'div' ? 'py-2' : ''
+
+  return (
+    <div className="space-y-6">
+      <div className="grid gap-2 sm:grid-cols-2">
+        <label className="flex flex-col text-sm">
+          Variant
+          <select value={variant} onChange={e => setVariant(e.target.value as any)} className="border border-border-subtle rounded p-1">
+            <option value="whisper">whisper</option>
+            <option value="note">note</option>
+            <option value="spark">spark</option>
+          </select>
+        </label>
+        <label className="flex flex-col text-sm">
+          As
+          <select value={asEl} onChange={e => setAsEl(e.target.value as any)} className="border border-border-subtle rounded p-1">
+            <option value="span">span</option>
+            <option value="div">div</option>
+          </select>
+        </label>
+        <label className="flex flex-col text-sm">
+          Icon
+          <select value={icon} onChange={e => setIcon(e.target.value as any)} className="border border-border-subtle rounded p-1">
+            <option value="none">none</option>
+            <option value="star">star</option>
+            <option value="sprout">sprout</option>
+            <option value="quill">quill</option>
+          </select>
+        </label>
+        <label className="flex flex-col text-sm">
+          Density
+          <select value={density} onChange={e => setDensity(e.target.value as any)} className="border border-border-subtle rounded p-1">
+            <option value="compact">compact</option>
+            <option value="comfy">comfy</option>
+          </select>
+        </label>
+        <label className="flex flex-col text-sm">
+          Tone
+          <select value={tone} onChange={e => setTone(e.target.value as any)} className="border border-border-subtle rounded p-1">
+            <option value="neutral">neutral</option>
+            <option value="brand">brand</option>
+            <option value="accent">accent</option>
+          </select>
+        </label>
+      </div>
+
+      <p>
+        Inline demo with{' '}
+        <ShoutOut
+          ref={ref as any}
+          as={asEl}
+          variant={variant}
+          icon={icon}
+          className={densityClass}
+          style={toneStyle as any}
+          tabIndex={0}
+        >
+          shouts to the chronicles wiki{' '}
+          <a href="https://dragonlance.fandom.com/wiki/Raistlin_Majere" className="underline hover:no-underline">Raistlin Majere</a>
+        </ShoutOut>
+        {' '}inside a sentence.
+      </p>
+
+      {asEl === 'div' && (
+        <ShoutOut
+          as="div"
+          variant={variant}
+          icon={icon}
+          className={densityClass}
+          style={toneStyle as any}
+          tabIndex={0}
+        >
+          shouts to the chronicles wiki{' '}
+          <a href="https://dragonlance.fandom.com/wiki/Raistlin_Majere" className="underline hover:no-underline">Raistlin Majere</a>
+        </ShoutOut>
+      )}
+
+      <p className="text-sm text-muted-foreground">Contrast ratio: {contrast}</p>
+      <button onClick={() => ref.current?.focus()} className="border border-border-subtle rounded px-2 py-1 text-sm">
+        Focus shout out
+      </button>
+    </div>
+  )
+}

--- a/app/ui-lab/shout-out/page.tsx
+++ b/app/ui-lab/shout-out/page.tsx
@@ -1,0 +1,15 @@
+import { buildPageMetadata } from '@/lib/page-metadata'
+import type { PageFrontmatter } from '@/types/frontmatter'
+import ShoutOutLab from './ShoutOutLab'
+
+const frontmatter = {
+  title: 'Shout Out',
+  description: 'ShoutOut component playground',
+  canonical: 'https://tullyelly.com/ui-lab/shout-out',
+} satisfies PageFrontmatter
+
+export const metadata = buildPageMetadata(frontmatter)
+
+export default function Page() {
+  return <ShoutOutLab />
+}

--- a/components/ChroniclesSection.tsx
+++ b/components/ChroniclesSection.tsx
@@ -1,4 +1,5 @@
 import Image from 'next/image';
+import ShoutOut from '@/components/shout-out';
 
 type Item = {
   slug: string;
@@ -99,10 +100,10 @@ export function ChroniclesSection({ date }: { date?: string }) {
 
       {/* Intro space */}
       <p className="mt-3 text-sm md:text-[15px] text-muted-foreground">
-        This project is my first crack at AI-human collaboration. I&rsquo;ve provided about half of the vision, structure, and problem-solving, while ChatGPT and Codex have written 90–95% of the code and guided me through the environment setup. It&rsquo;s the most fun I&rsquo;ve ever had building and executing against a project plan.
+        This project is my first crack at AI-human collaboration. I’ve provided about half of the vision, structure, and problem-solving, while ChatGPT and Codex have written 90–95% of the code and guided me through the environment setup. It’s the most fun I’ve ever had building and executing against a project plan.
       </p>
       <p className="mt-3 text-sm md:text-[15px] text-muted-foreground">
-        Here&rsquo;s our pal summarizing the foundation of what we build upon:
+        Here’s our pal summarizing the foundation of what we build upon:
       </p>
 
       {/* Intro bookend paragraph (Purpose) */}
@@ -167,15 +168,16 @@ export function ChroniclesSection({ date }: { date?: string }) {
 
       {/* Closing shout with external link */}
       <p className="mt-3 text-sm md:text-[15px] text-muted-foreground">
-        shouts to the chronicles wiki{' '}
-        <a
-          href="https://dragonlance.fandom.com/wiki/Raistlin_Majere"
-          className="underline hover:no-underline"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Raistlin Majere
-        </a>
+        <ShoutOut>shouts to the chronicles wiki{' '}
+          <a
+            href="https://dragonlance.fandom.com/wiki/Raistlin_Majere"
+            className="underline hover:no-underline"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Raistlin Majere
+          </a>
+        </ShoutOut>
       </p>
     </section>
   );

--- a/components/ShaolinScrollsSection.tsx
+++ b/components/ShaolinScrollsSection.tsx
@@ -1,4 +1,5 @@
 import { Suspense } from 'react';
+import ShoutOut from '@/components/shout-out';
 import ScrollsTablePanel from '@/components/scrolls/ScrollsTablePanel';
 
 export function ShaolinScrollsSection({ date }: { date?: string }) {
@@ -20,34 +21,32 @@ export function ShaolinScrollsSection({ date }: { date?: string }) {
 
       {/* Closing shout with external links */}
       <p className="mt-3 text-sm md:text-[15px] text-muted-foreground">
-        shouts to{' '}
-        <a
-          href="https://www.postgresql.org/"
-          className="underline hover:no-underline"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Postgres
-        </a>
-        {', '}
-        <a
-          href="https://neon.tech/"
-          className="underline hover:no-underline"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Neon
-        </a>
-        {' & '}
-        <a
-          href="https://www.jetbrains.com/datagrip/"
-          className="underline hover:no-underline"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          DataGrip
-        </a>{' '}
-        for helping with my falling in love with databases all over again.
+        <ShoutOut>shouts to{' '}
+          <a
+            href="https://www.postgresql.org/"
+            className="underline hover:no-underline"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Postgres
+          </a>,{' '}
+          <a
+            href="https://neon.tech/"
+            className="underline hover:no-underline"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Neon
+          </a>{' & '}
+          <a
+            href="https://www.jetbrains.com/datagrip/"
+            className="underline hover:no-underline"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            DataGrip
+          </a>{' '}for helping with my falling in love with databases all over again.
+        </ShoutOut>
       </p>
     </section>
   );

--- a/components/shout-out.tsx
+++ b/components/shout-out.tsx
@@ -1,0 +1,78 @@
+
+import { ReactNode, forwardRef, HTMLAttributes } from 'react'
+import { cn } from '@/lib/cn'
+
+type ShoutOutProps = {
+  children: ReactNode
+  variant?: 'whisper' | 'note' | 'spark'
+  icon?: 'none' | 'star' | 'sprout' | 'quill'
+  as?: 'span' | 'div'
+} & HTMLAttributes<HTMLElement>
+
+const icons = {
+  star: (
+    <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+      <path fillRule="evenodd" d="M10.788 3.21c.448-1.077 1.976-1.077 2.424 0l2.082 5.006 5.404.434c1.164.093 1.636 1.545.749 2.305l-4.117 3.527 1.257 5.273c.271 1.136-.964 2.033-1.96 1.425L12 18.354 7.373 21.18c-.996.608-2.231-.29-1.96-1.425l1.257-5.273-4.117-3.527c-.887-.76-.415-2.212.749-2.305l5.404-.434 2.082-5.005Z" clipRule="evenodd"/>
+    </svg>
+  ),
+  sprout: (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M14 9.536V7a4 4 0 0 1 4-4h1.5a.5.5 0 0 1 .5.5V5a4 4 0 0 1-4 4 4 4 0 0 0-4 4c0 2 1 3 1 5a5 5 0 0 1-1 3" />
+      <path d="M4 9a5 5 0 0 1 8 4 5 5 0 0 1-8-4" />
+      <path d="M5 21h14" />
+    </svg>
+  ),
+  quill: (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M12.67 19a2 2 0 0 0 1.416-.588l6.154-6.172a6 6 0 0 0-8.49-8.49L5.586 9.914A2 2 0 0 0 5 11.328V18a1 1 0 0 0 1 1z" />
+      <path d="M16 8 2 22" />
+      <path d="M17.5 15H9" />
+    </svg>
+  ),
+}
+
+const ShoutOut = forwardRef<HTMLSpanElement | HTMLDivElement, ShoutOutProps>(
+  function ShoutOut(
+    { children, variant = 'whisper', icon = 'star', as: Component = 'span', className, style, ...rest }: ShoutOutProps,
+    ref,
+  ) {
+    const Icon = icon === 'none' ? null : icons[icon]
+    return (
+      <Component
+        ref={ref as any}
+        role="note"
+        aria-label="Shout out"
+        data-variant={variant}
+        className={cn(
+          'so-inline text-[0.95em] font-medium tracking-wide text-muted-foreground',
+          Component === 'div' ? 'block' : '',
+          variant === 'note' && Component === 'div' ? 'px-2 py-1' : '',
+          className,
+        )}
+        style={style}
+        {...rest}
+      >
+        {Icon && <span className="so-icon inline-flex" aria-hidden>{Icon}</span>}
+        {children}
+      </Component>
+    )
+  },
+)
+
+export default ShoutOut

--- a/docs/ui/shout-out-notes.md
+++ b/docs/ui/shout-out-notes.md
@@ -1,0 +1,16 @@
+# Shout Out Inventory Notes
+
+Current places where “shout” style asides appear without a dedicated component:
+
+- `components/ChroniclesSection.tsx` – closing line “shouts to the chronicles wiki Raistlin Majere” styled with `text-muted-foreground`.
+- `components/ShaolinScrollsSection.tsx` – closing line “shouts to Postgres, Neon & DataGrip…” also using `text-muted-foreground`.
+- `app/heels-have-eyes/page.tsx` – inline “Shouts to Denny LaFlare.” in body copy.
+- `components/Callout.tsx` – ad‑hoc `<aside role="note" class="callout">` with no shared styling.
+
+Existing typography/color tokens related to muted or accent text:
+
+- Tailwind class `text-muted-foreground` mapped to `--muted-foreground`.
+- Global `.muted` helper in `app/globals.css` using a 60% mix of `--text-primary` and `--surface-page`.
+- `.bucks-accent` utility for brand accent color (`--blue`).
+
+These usages should consolidate on the upcoming `ShoutOut` component and shared CSS variables `--so-accent` and `--so-bg`.

--- a/docs/ui/shout-out.md
+++ b/docs/ui/shout-out.md
@@ -1,0 +1,34 @@
+# Shout Out
+
+A lightweight, personality-forward aside for quick editorial notes or playful credits without the heaviness of a card.
+
+## When to use
+Use sparingly to highlight fun footnotes or personal asides inline with text. Keep usage tight and let surrounding copy carry the main narrative.
+
+## MDX snippets
+Inline:
+
+```mdx
+<ShoutOut>shouts to the chronicles wiki <a href="https://dragonlance.fandom.com/wiki/Raistlin_Majere">Raistlin Majere</a></ShoutOut>
+```
+
+Block:
+
+```mdx
+<ShoutOut as="div" variant="note" icon="sprout">
+  Keep your database tidy.
+</ShoutOut>
+```
+
+## Variants
+
+| variant | description |
+| ------- | ----------- |
+| whisper | subtle left accent, no background |
+| note    | dotted edge with soft background |
+| spark   | faint underline that brightens on hover |
+
+## Accessibility & guidelines
+- `role="note"` with `aria-label="Shout out"` is applied automatically.
+- Avoid link-only shout outs and keep content to roughly 150 characters or less.
+- Ensure sufficient color contrast when overriding the accent tone.

--- a/lib/mdx/shout-out-remark.ts
+++ b/lib/mdx/shout-out-remark.ts
@@ -1,0 +1,14 @@
+import { visit } from 'unist-util-visit'
+import type { Plugin } from 'unified'
+
+const remarkShoutOut: Plugin = () => (tree: unknown) => {
+  visit(tree as any, (node: any) => {
+    if (node.type === 'containerDirective' && node.name === 'shout-out') {
+      node.data ??= {}
+      node.data.hName = 'ShoutOut'
+      node.data.hProperties = { as: 'div', variant: 'note' }
+    }
+  })
+}
+
+export default remarkShoutOut

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -2,11 +2,20 @@
 import createMDX from '@next/mdx';
 import remarkFrontmatter from 'remark-frontmatter';
 import remarkMdxFrontmatter from 'remark-mdx-frontmatter';
+import jiti from 'jiti';
+
+const remarkPlugins = [remarkFrontmatter, remarkMdxFrontmatter]
+if (process.env.ENABLE_SHOUT_OUT_REMARK === '1') {
+  const j = jiti(import.meta.url)
+  const remarkDirective = j('remark-directive').default
+  const shoutOutRemark = j('./lib/mdx/shout-out-remark.ts').default
+  remarkPlugins.push(remarkDirective, shoutOutRemark)
+}
 
 const withMDX = createMDX({
   extension: /\.mdx?$/,
   options: {
-    remarkPlugins: [remarkFrontmatter, remarkMdxFrontmatter],
+    remarkPlugins,
   },
 });
 


### PR DESCRIPTION
## Summary
- introduce inline-first `ShoutOut` component with three variants and optional icons
- document usage and inventory notes
- add Shout Out playground in UI Lab

## Testing
- `npm run lint`
- `npm run typecheck`
- `TEST_DATABASE_URL=postgres://user:pass@localhost:5432/db npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8a2dcbc70832e98b7ece51b4b3232