### PR TITLE
[WU-255] Remove Flowers from Shaolin Scrolls app

### DIFF
--- a/app/shaolin-scrolls/page.tsx
+++ b/app/shaolin-scrolls/page.tsx
@@ -1,6 +1,5 @@
 import ActionBar from './_components/ActionBar';
 import ScrollsPageClient from './_components/ScrollsPageClient';
-import FlowersInline from '@/components/flowers/FlowersInline';
 import { getScrollsPage } from '@/lib/scrolls';
 import type { Sort } from '@/lib/releases';
 
@@ -34,51 +33,7 @@ export default async function Page({ searchParams }: PageProps) {
     <section id="scrolls-root" className="flex min-h-screen flex-col gap-4">
       <h1 className="text-xl font-semibold">Shaolin Scrolls</h1>
       <ActionBar q={q} />
-      <p className="text-sm md:text-[15px] text-muted-foreground">
-        <FlowersInline>
-          Chronicles wiki &{' '}
-          <a
-            href="https://dragonlance.fandom.com/wiki/Raistlin_Majere"
-            className="underline hover:no-underline"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Raistlin Majere
-          </a>
-        </FlowersInline>
-      </p>
       <ScrollsPageClient rows={rows} />
-      <p className="text-sm md:text-[15px] text-muted-foreground">
-        <FlowersInline>
-          <a
-            href="https://www.postgresql.org/"
-            className="underline hover:no-underline"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            PostgreSQL
-          </a>
-          {', '}
-          <a
-            href="https://neon.tech/"
-            className="underline hover:no-underline"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Neon
-          </a>
-          {' & '}
-          <a
-            href="https://www.jetbrains.com/datagrip/"
-            className="underline hover:no-underline"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            DataGrip
-          </a>
-          {'—rekindled my database crush.'}
-        </FlowersInline>
-      </p>
     </section>
   );
 }

--- a/e2e/flowers.spec.ts
+++ b/e2e/flowers.spec.ts
@@ -6,8 +6,8 @@ test('credits page renders Flowers heading and aria-labeled element', async ({ p
   await expect(page.getByRole('region', { name: 'Acknowledgments' })).toBeVisible();
 });
 
-test('shaolin scrolls shows Flowers inline notes at top and bottom', async ({ page }) => {
-  await page.goto('/shaolin-scrolls');
+test('home page shows Flowers inline notes for sections', async ({ page }) => {
+  await page.goto('/');
   await expect(
     page.getByLabel('Acknowledgments').filter({ hasText: 'Chronicles wiki' })
   ).toBeVisible();
@@ -16,4 +16,9 @@ test('shaolin scrolls shows Flowers inline notes at top and bottom', async ({ pa
       .getByLabel('Acknowledgments')
       .filter({ hasText: 'PostgreSQL, Neon & DataGrip—rekindled my database crush.' })
   ).toBeVisible();
+});
+
+test('shaolin scrolls page omits Flowers inline notes', async ({ page }) => {
+  await page.goto('/shaolin-scrolls');
+  await expect(page.getByLabel('Acknowledgments')).toHaveCount(0);
 });


### PR DESCRIPTION
## Summary
- remove homepage-only Flowers notes from `/shaolin-scrolls`
- verify Flowers notes only render on homepage sections
- adjust Flowers e2e coverage for new locations

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run test:e2e` *(fails: 12 failing tests)*


------
https://chatgpt.com/codex/tasks/task_e_68b8e3b569f8832eb49b62e99c46fe3f