### PR TITLE
[WU-000] enforce strict env and type checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,9 @@ jobs:
       - name: Lint
         run: npm run lint
 
+      - name: Typecheck
+        run: npm run typecheck
+
       - name: Optimize images (changed only)
         if: steps.filter.outputs.images == 'true'
         run: npm run images:optimize

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Recommended Node version: **20**.
 
 * `npm run lint` – lint the codebase
 * `npm run typecheck` – run TypeScript checks
+* `npm run deadcode` – list unused exports
 * `npm run build` – build the production bundle
 * `npm run start` – start the production server
 * `npm run ci` – run lint, image checks, and build

--- a/app/ui/__tests__/badge-maps.test.ts
+++ b/app/ui/__tests__/badge-maps.test.ts
@@ -1,7 +1,15 @@
 import { BADGE_VARIANTS, getBadgeClass } from "@/app/ui/badge-maps";
 
 test("badge variants contain expected keys", () => {
-  for (const k of ["planned", "released", "hotfix", "archived", "minor", "major", "classic"]) {
+  for (const k of [
+    "planned",
+    "released",
+    "hotfix",
+    "archived",
+    "minor",
+    "major",
+    "classic",
+  ] as Array<keyof typeof BADGE_VARIANTS>) {
     expect(BADGE_VARIANTS[k]).toBeTruthy();
   }
 });

--- a/lib/auth-config.ts
+++ b/lib/auth-config.ts
@@ -43,7 +43,7 @@ function parseRules(): Rules {
           : DEFAULT_RULES.toggles?.allowAnyEmailOnPreview)
     };
     return {
-      ownerDomains: unique(ownerDomains.map(s => s.toLowerCase())),
+      ownerDomains: unique(ownerDomains.map((s: string) => s.toLowerCase())),
       publicPaths: unique(publicPaths),
       protectedPaths: unique(protectedPaths),
       ownerOnlyPaths: unique(ownerOnlyPaths),

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -1,1 +1,7 @@
-export const DATABASE_URL = process.env.DATABASE_URL ?? null;
+import { z } from "zod";
+
+const Env = z.object({
+  DATABASE_URL: z.string().url(),
+});
+
+export const { DATABASE_URL } = Env.parse(process.env);

--- a/lib/releases.ts
+++ b/lib/releases.ts
@@ -125,7 +125,7 @@ export async function getReleases({ limit, offset, sort, q }: ReleaseListParams)
     db.query<{ total: number }>(sqlCount, countValues),
   ]);
 
-  const items: ReleaseRow[] = itemsRes.rows.map(row => ({
+  const items: ReleaseRow[] = itemsRes.rows.map((row: DbReleaseRow) => ({
     ...row,
     id: String(row.id),
     created_at: new Date(row.created_at).toISOString(),

--- a/lib/scrolls.ts
+++ b/lib/scrolls.ts
@@ -89,7 +89,7 @@ export async function getScrollsPage({
     db.query<{ total: number }>(sqlCount, countValues),
   ]);
 
-  const items: ScrollRow[] = itemsRes.rows.map((row) => ({
+  const items: ScrollRow[] = itemsRes.rows.map((row: ScrollDbRow) => ({
     id: String(row.id),
     label: row.label,
     status: row.status,

--- a/lib/sentry.ts
+++ b/lib/sentry.ts
@@ -10,8 +10,8 @@ export async function initSentry() {
     tracesSampleRate: 1,
     release: buildInfo.commit,
     environment: process.env.VERCEL_ENV || process.env.NODE_ENV,
-    integrations: (integrations) =>
-      integrations.filter((i: any) => i.name !== "Prisma"),
+    integrations: (integrations: Array<{ name?: string }>) =>
+      integrations.filter((i) => i.name !== "Prisma"),
   });
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,8 @@
         "pg": "^8.16.3",
         "react": "19.1.0",
         "react-dom": "19.1.0",
-        "sharp": "^0.34.3"
+        "sharp": "^0.34.3",
+        "zod": "^4.0.17"
       },
       "devDependencies": {
         "@eslint/css": "^0.10.0",
@@ -38,7 +39,9 @@
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.8.0",
         "@testing-library/react": "^16.3.0",
+        "@types/fs-extra": "^11.0.4",
         "@types/jest": "^30.0.0",
+        "@types/jest-axe": "^3.5.9",
         "@types/node": "^24.3.0",
         "@types/pg": "^8.15.5",
         "@types/react": "^19.1.10",
@@ -66,10 +69,10 @@
         "server-only": "^0.0.1",
         "tailwindcss": "^4",
         "ts-jest": "^29.4.1",
+        "ts-prune": "^0.10.3",
         "tsx": "^4.20.5",
         "typescript": "^5.9.2",
-        "typescript-eslint": "^8.41.0",
-        "zod": "^4.0.17"
+        "typescript-eslint": "^8.41.0"
       },
       "optionalDependencies": {
         "lightningcss-linux-x64-gnu": "^1.30.1"
@@ -5454,6 +5457,32 @@
         }
       }
     },
+    "node_modules/@ts-morph/common": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.12.3.tgz",
+      "integrity": "sha512-4tUmeLyXJnJWvTFOKtcNJ1yh0a3SsTLi2MUoyj8iUNznFRN1ZquaNe7Oukqrnki2FzZkm0J9adCNLDZxUzvj+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-glob": "^3.2.7",
+        "minimatch": "^3.0.4",
+        "mkdirp": "^1.0.4",
+        "path-browserify": "^1.0.1"
+      }
+    },
+    "node_modules/@ts-morph/common/node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.0.tgz",
@@ -5564,6 +5593,17 @@
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "license": "MIT"
     },
+    "node_modules/@types/fs-extra": {
+      "version": "11.0.4",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-11.0.4.tgz",
+      "integrity": "sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/jsonfile": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/hast": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
@@ -5610,6 +5650,27 @@
       "dependencies": {
         "expect": "^30.0.0",
         "pretty-format": "^30.0.0"
+      }
+    },
+    "node_modules/@types/jest-axe": {
+      "version": "3.5.9",
+      "resolved": "https://registry.npmjs.org/@types/jest-axe/-/jest-axe-3.5.9.tgz",
+      "integrity": "sha512-z98CzR0yVDalCEuhGXXO4/zN4HHuSebAukXDjTLJyjEAgoUf1H1i+sr7SUB/mz8CRS/03/XChsx0dcLjHkndoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/jest": "*",
+        "axe-core": "^3.5.5"
+      }
+    },
+    "node_modules/@types/jest-axe/node_modules/axe-core": {
+      "version": "3.5.6",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.5.6.tgz",
+      "integrity": "sha512-LEUDjgmdJoA3LqklSTwKYqkjcZ4HKc4ddIYGSAiSkr46NTjzg2L9RNB+lekO9P7Dlpa87+hBtzc2Fzn/+GUWMQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/@types/jest/node_modules/ansi-styles": {
@@ -5672,6 +5733,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/jsonfile": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/@types/jsonfile/-/jsonfile-6.1.4.tgz",
+      "integrity": "sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/mdast": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
@@ -5713,6 +5784,13 @@
       "dependencies": {
         "undici-types": "~7.10.0"
       }
+    },
+    "node_modules/@types/parse-json": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
+      "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/pg": {
       "version": "8.15.5",
@@ -7573,6 +7651,13 @@
         "node": ">= 0.12.0"
       }
     },
+    "node_modules/code-block-writer": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-11.0.3.tgz",
+      "integrity": "sha512-NiujjUFB4SwScJq2bwbYUtXbZhBSlY6vYzm++3Q6oC+U+injTqfPYFK8wS9COOmb2lueqp0ZRB4nK1VYeHgNyw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/collect-v8-coverage": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.2.tgz",
@@ -7671,6 +7756,43 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/cosmiconfig": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/cosmiconfig/node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cosmiconfig/node_modules/yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/cross-env": {
@@ -12733,6 +12855,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -14574,6 +14703,13 @@
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
+    },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -16836,6 +16972,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/true-myth": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/true-myth/-/true-myth-4.1.1.tgz",
+      "integrity": "sha512-rqy30BSpxPznbbTcAcci90oZ1YR4DqvKcNXNerG5gQBU2v4jk0cygheiul5J6ExIMrgDVuanv/MkGfqZbKrNNg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "10.* || >= 12.*"
+      }
+    },
     "node_modules/ts-api-utils": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
@@ -16926,6 +17072,45 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ts-morph": {
+      "version": "13.0.3",
+      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-13.0.3.tgz",
+      "integrity": "sha512-pSOfUMx8Ld/WUreoSzvMFQG5i9uEiWIsBYjpU9+TTASOeUa89j5HykomeqVULm1oqWtBdleI3KEFRLrlA3zGIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ts-morph/common": "~0.12.3",
+        "code-block-writer": "^11.0.0"
+      }
+    },
+    "node_modules/ts-prune": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/ts-prune/-/ts-prune-0.10.3.tgz",
+      "integrity": "sha512-iS47YTbdIcvN8Nh/1BFyziyUqmjXz7GVzWu02RaZXqb+e/3Qe1B7IQ4860krOeCGUeJmterAlaM2FRH0Ue0hjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^6.2.1",
+        "cosmiconfig": "^7.0.1",
+        "json5": "^2.1.3",
+        "lodash": "^4.17.21",
+        "true-myth": "^4.1.0",
+        "ts-morph": "^13.0.1"
+      },
+      "bin": {
+        "ts-prune": "lib/index.js"
+      }
+    },
+    "node_modules/ts-prune/node_modules/commander": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/tsconfig-paths": {
@@ -18116,7 +18301,6 @@
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.5.tgz",
       "integrity": "sha512-rcUUZqlLJgBC33IT3PNMgsCq6TzLQEG/Ei/KTCU0PedSWRMAXoOUN+4t/0H+Q8bdnLPdqUYnvboJT0bn/229qg==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -25,9 +25,10 @@
     "validate-frontmatter": "node scripts/validate-frontmatter.mjs",
     "validate-seo": "node scripts/validate-seo.mjs",
     "ensure:diag-off": "node -e \"if(process.env.NEXT_PUBLIC_HYDRATION_DIAG && process.env.NEXT_PUBLIC_HYDRATION_DIAG !== '0'){console.error('Hydration diagnostics must be disabled in prod');process.exit(1)}\"",
-    "ci": "npm run ensure:diag-off && npm run lint && npm run images:optimize && npm run images:check && npm run validate-frontmatter && npm run validate-seo && npm run build",
+    "ci": "npm run ensure:diag-off && npm run lint && npm run typecheck && npm run images:optimize && npm run images:check && npm run validate-frontmatter && npm run validate-seo && npm run build",
     "typecheck": "tsc --noEmit",
     "pretypecheck": "node scripts/gen-build-info.mjs",
+    "deadcode": "ts-prune",
     "test": "cross-env NODE_ENV=test jest",
     "pretest": "npm run gen:build-info",
     "test:ci": "cross-env NODE_ENV=test jest --runInBand",
@@ -54,7 +55,8 @@
     "pg": "^8.16.3",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "sharp": "^0.34.3"
+    "sharp": "^0.34.3",
+    "zod": "^4.0.17"
   },
   "devDependencies": {
     "@eslint/css": "^0.10.0",
@@ -75,6 +77,8 @@
     "@types/jest": "^30.0.0",
     "@types/node": "^24.3.0",
     "@types/pg": "^8.15.5",
+    "@types/jest-axe": "^3.5.9",
+    "@types/fs-extra": "^11.0.4",
     "@types/react": "^19.1.10",
     "@types/react-dom": "^19.1.7",
     "cross-env": "^7.0.3",
@@ -101,8 +105,8 @@
     "tailwindcss": "^4",
     "ts-jest": "^29.4.1",
     "tsx": "^4.20.5",
+    "ts-prune": "^0.10.3",
     "typescript": "^5.9.2",
-    "typescript-eslint": "^8.41.0",
-    "zod": "^4.0.17"
+    "typescript-eslint": "^8.41.0"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -41,6 +41,10 @@ export default defineConfig({
       AUTH_RULES_JSON:
         '{"ownerDomains":["tullyelly.com"],"publicPaths":["/","/login","/api/auth"],"protectedPaths":[],"ownerOnlyPaths":[],"toggles":{"allowAnyEmailOnPreview":true}}',
       AUTH_SECRET: "test-secret",
+      DATABASE_URL:
+        process.env.TEST_DATABASE_URL ||
+        process.env.DATABASE_URL ||
+        "postgresql://dummy:dummy@127.0.0.1:5432/dummy?sslmode=disable&options=-c%20search_path%3Dauth%2Cdojo%2Cpublic",
     },
   },
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
     ],
     "allowJs": true,
     "skipLibCheck": true,
-    "strict": false,
+    "strict": true,
     "noEmit": true,
     "incremental": true,
     "module": "esnext",


### PR DESCRIPTION
## Summary
- enable TypeScript strict mode and validate `DATABASE_URL` with Zod
- add `typecheck` to CI and `ts-prune` helper script
- tighten typings to satisfy strict checks
- provide default `DATABASE_URL` in Playwright config for local e2e runs
- move `zod` to runtime dependencies so env parsing works in production
- run `typecheck` as part of `npm run ci`

## Testing
- `npm run lint`
- `npm run typecheck`
- `TEST_DATABASE_URL=postgresql://dummy:dummy@127.0.0.1:5432/dummy?sslmode=disable npm test`
- `TEST_DATABASE_URL=postgresql://dummy:dummy@127.0.0.1:5432/dummy?sslmode=disable npx playwright test --reporter=html` *(fails: 11 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b8dc84ec38832e9a5ca2475913af21