### PR TITLE
[WU-0000] Fix mobile date wrapping and layout colors

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -30,7 +30,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en" className={`${inter.variable} ${jbMono.variable}`}>
       <head></head>
-      <body className="font-sans min-h-screen flex flex-col bg-[#EEE1C6] text-foreground">
+      <body className="font-sans min-h-screen flex flex-col bg-white text-foreground">
         <Providers>
           {announcement && <AnnouncementBanner message={announcement} dismissible />}
 
@@ -38,8 +38,8 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             <NavBar />
           </header>
 
-          <main id="content" className="flex-1 p-4" tabIndex={-1}>
-            <div className="mx-auto w-full max-w-7xl bg-white rounded-lg shadow-sm p-6">
+          <main id="content" className="flex-1 bg-white" tabIndex={-1}>
+            <div className="mx-auto w-full max-w-7xl px-4 py-6">
               {children}
             </div>
           </main>

--- a/components/ChroniclesSection.tsx
+++ b/components/ChroniclesSection.tsx
@@ -95,7 +95,8 @@ export function ChroniclesSection({ date }: { date?: string }) {
     <section id="chronicles" aria-labelledby="chronicles-heading" className="scroll-mt-24">
       {/* Heading */}
       <h2 id="chronicles-heading" className="text-xl md:text-2xl font-semibold leading-snug">
-        <span aria-hidden>📓</span>Chronicle of Chronicles{date ? `; ${date}` : ''}
+        <span aria-hidden>📓</span>Chronicle of Chronicles
+        {date && <span className="ml-1 whitespace-nowrap">; {date}</span>}
       </h2>
 
       {/* Intro space */}


### PR DESCRIPTION
## Summary
- keep Chronicle date together and allow wrapping to new line on narrow screens
- remove cream gutters so header/footer are blue and body is white

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test` *(fails: Missing env var TEST_DATABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_68b941255b2c832ea88eb81b79087e96