### PR TITLE
[WU-256] add Mother's Day 2025 section

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,10 @@ Humans: see `README.md` for introductions and contributor docs.
 - Scope: MD/MDX text and JSX/TSX JSXText.
 - Exceptions: tests, vendor, or quotes annotated with `// punctuation-allowed` or frontmatter `punctuation: allowed`.
 
+## Flowers & Credits
+
+- Use `FlowersInline` for section-level acknowledgments; mirror the Chronicles and Shaolin Scrolls patterns.
+- Show at most one Flowers call per section and surface matching items on `/credits`.
 
 ## Testing & CI Expectations
 

--- a/README.md
+++ b/README.md
@@ -227,4 +227,5 @@ npx vercel --prod --token "$VERCEL_TOKEN"
 * Set `NEXT_PUBLIC_ANNOUNCEMENT` to display the top banner
 * Always run `npm run images:optimize` before committing new images
 * `app/shaolin-scrolls`: responsive release list with Radix details dialog
+* `app/page.tsx`: homepage with Mother's Day 2025, Chronicle of Chronicles, and Shaolin Scrolls sections
 * Security headers configured in `next.config.mjs` enforce HSTS, deny framing, and prevent MIME sniffing.

--- a/README.md
+++ b/README.md
@@ -228,4 +228,5 @@ npx vercel --prod --token "$VERCEL_TOKEN"
 * Always run `npm run images:optimize` before committing new images
 * `app/shaolin-scrolls`: responsive release list with Radix details dialog
 * `app/page.tsx`: homepage with Mother's Day 2025, Chronicle of Chronicles, and Shaolin Scrolls sections
+* `app/credits`: sources & acknowledgments via Flowers
 * Security headers configured in `next.config.mjs` enforce HSTS, deny framing, and prevent MIME sniffing.

--- a/app/credits/page.tsx
+++ b/app/credits/page.tsx
@@ -62,6 +62,37 @@ export default function Page() {
               </a>
             </span>
           ),
+          (
+            <span key="3">
+              nikkigirl, Big Ter,{" "}
+              <a
+                href="https://www.youtube.com/"
+                className="underline hover:no-underline"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                YouTube
+              </a>
+              {", "}
+              <a
+                href="https://www.python.org/"
+                className="underline hover:no-underline"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Python
+              </a>
+              {" & "}
+              <a
+                href="https://www.kapwing.com/"
+                className="underline hover:no-underline"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Kapwing
+              </a>
+            </span>
+          ),
         ]}
       />
     </main>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,13 +5,16 @@ export const revalidate = 0;
 // no local Suspense usage; kept within child sections
 import { ChroniclesSection } from '@/components/ChroniclesSection';
 import { ShaolinScrollsSection } from '@/components/ShaolinScrollsSection';
+import { MothersDaySection } from '@/components/MothersDaySection';
 
 export default function Home() {
   const chroniclesDate = '2025-09-03';
   const scrollsDate = '2025-09-01';
+  const mothersDate = '2025-09-04';
   return (
     <main className="space-y-4">
       <h1 className="text-2xl font-semibold">Welcome</h1>
+      <MothersDaySection date={mothersDate} />
       <ChroniclesSection date={chroniclesDate} />
       <ShaolinScrollsSection date={scrollsDate} />
     </main>

--- a/components/MothersDaySection.tsx
+++ b/components/MothersDaySection.tsx
@@ -13,7 +13,7 @@ export function MothersDaySection({ date }: Props) {
         <figure className="space-y-2">
           <div className="yt-wrapper-bucks">
             <iframe
-              src="https://www.youtube-nocookie.com/embed/br1qpJ2mCpE"
+              src="https://www.youtube-nocookie.com/embed/n8fOQ4DOZTk"
               title="Mother&apos;s Day video 1"
               loading="lazy"
               allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
@@ -28,7 +28,7 @@ export function MothersDaySection({ date }: Props) {
         <figure className="space-y-2">
           <div className="yt-wrapper-bucks">
             <iframe
-              src="https://www.youtube-nocookie.com/embed/n8fOQ4DOZTk"
+              src="https://www.youtube-nocookie.com/embed/br1qpJ2mCpE"
               title="Mother&apos;s Day video 2"
               loading="lazy"
               allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"

--- a/components/MothersDaySection.tsx
+++ b/components/MothersDaySection.tsx
@@ -1,3 +1,5 @@
+import FlowersInline from '@/components/flowers/FlowersInline';
+
 type Props = { date?: string };
 
 export function MothersDaySection({ date }: Props) {
@@ -14,62 +16,63 @@ export function MothersDaySection({ date }: Props) {
           <div className="yt-wrapper-bucks">
             <iframe
               src="https://www.youtube-nocookie.com/embed/n8fOQ4DOZTk"
-              title="Mother&apos;s Day video 1"
+              title="Mother's Day video 1"
               loading="lazy"
               allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
               referrerPolicy="strict-origin-when-cross-origin"
               allowFullScreen
             />
           </div>
-          <figcaption className="space-y-1 text-xs text-fg/60">
-            <p>Embedded via YouTube&apos;s privacy-enhanced player.</p>
-            <p>
-              <span aria-hidden>🌸</span> nikkigirl, Big Ter,{' '}
-              <a className="underline" href="https://www.youtube.com/">
-                YouTube
-              </a>
-              ,{' '}
-              <a className="underline" href="https://www.python.org/">
-                Python
-              </a>
-              , &{' '}
-              <a className="underline" href="https://www.kapwing.com/">
-                Kapwing
-              </a>{' '}
-              <span aria-hidden>🌸</span>
-            </p>
+          <figcaption className="text-xs text-fg/60">
+            Embedded via YouTube&apos;s privacy-enhanced player.
           </figcaption>
         </figure>
         <figure className="space-y-2">
           <div className="yt-wrapper-bucks">
             <iframe
               src="https://www.youtube-nocookie.com/embed/br1qpJ2mCpE"
-              title="Mother&apos;s Day video 2"
+              title="Mother's Day video 2"
               loading="lazy"
               allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
               referrerPolicy="strict-origin-when-cross-origin"
               allowFullScreen
             />
           </div>
-          <figcaption className="space-y-1 text-xs text-fg/60">
-            <p>Embedded via YouTube&apos;s privacy-enhanced player.</p>
-            <p>
-              <span aria-hidden>🌸</span> nikkigirl, Big Ter,{' '}
-              <a className="underline" href="https://www.youtube.com/">
-                YouTube
-              </a>
-              ,{' '}
-              <a className="underline" href="https://www.python.org/">
-                Python
-              </a>
-              , &{' '}
-              <a className="underline" href="https://www.kapwing.com/">
-                Kapwing
-              </a>{' '}
-              <span aria-hidden>🌸</span>
-            </p>
+          <figcaption className="text-xs text-fg/60">
+            Embedded via YouTube&apos;s privacy-enhanced player.
           </figcaption>
         </figure>
+        <p className="mt-3 text-sm md:text-[15px] text-muted-foreground">
+          <FlowersInline>
+            nikkigirl, Big Ter,{" "}
+            <a
+              className="underline hover:no-underline"
+              href="https://www.youtube.com/"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              YouTube
+            </a>
+            {", "}
+            <a
+              className="underline hover:no-underline"
+              href="https://www.python.org/"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Python
+            </a>
+            {" & "}
+            <a
+              className="underline hover:no-underline"
+              href="https://www.kapwing.com/"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Kapwing
+            </a>
+          </FlowersInline>
+        </p>
       </div>
     </section>
   );

--- a/components/MothersDaySection.tsx
+++ b/components/MothersDaySection.tsx
@@ -9,7 +9,7 @@ export function MothersDaySection({ date }: Props) {
         <span aria-hidden>🌷</span>Mother&apos;s Day 2025{date ? `; ${date}` : ''}
       </h2>
       <p className="text-sm">
-        Before we dive too deep into the nerd, here's some additional wholesome Mother's Day content for you to enjoy! I found them to be just as impactful as the first time around.
+        Before we dive too deep into the nerd, here&apos;s some additional wholesome Mother&apos;s Day content for you to enjoy! I found them to be just as impactful as the first time around.
       </p>
       <div className="space-y-4">
         <figure className="space-y-2">

--- a/components/MothersDaySection.tsx
+++ b/components/MothersDaySection.tsx
@@ -9,7 +9,7 @@ export function MothersDaySection({ date }: Props) {
         <span aria-hidden>🌷</span>Mother&apos;s Day 2025{date ? `; ${date}` : ''}
       </h2>
       <p className="text-sm">
-        A heartfelt introduction will appear here when the time is right; for now please enjoy the videos below.
+        Before we dive too deep into the nerd, here's some additional wholesome Mother's Day content for you to enjoy! I found them to be just as impactful as the first time around.
       </p>
       <div className="space-y-4">
         <figure className="space-y-2">
@@ -22,10 +22,7 @@ export function MothersDaySection({ date }: Props) {
               referrerPolicy="strict-origin-when-cross-origin"
               allowFullScreen
             />
-          </div>
-          <figcaption className="text-xs text-fg/60">
-            Embedded via YouTube&apos;s privacy-enhanced player.
-          </figcaption>
+          </div>          
         </figure>
         <figure className="space-y-2">
           <div className="yt-wrapper-bucks">

--- a/components/MothersDaySection.tsx
+++ b/components/MothersDaySection.tsx
@@ -21,8 +21,23 @@ export function MothersDaySection({ date }: Props) {
               allowFullScreen
             />
           </div>
-          <figcaption className="text-xs text-fg/60">
-            Embedded via YouTube&apos;s privacy-enhanced player.
+          <figcaption className="space-y-1 text-xs text-fg/60">
+            <p>Embedded via YouTube&apos;s privacy-enhanced player.</p>
+            <p>
+              <span aria-hidden>🌸</span> nikkigirl, Big Ter,{' '}
+              <a className="underline" href="https://www.youtube.com/">
+                YouTube
+              </a>
+              ,{' '}
+              <a className="underline" href="https://www.python.org/">
+                Python
+              </a>
+              , &{' '}
+              <a className="underline" href="https://www.kapwing.com/">
+                Kapwing
+              </a>{' '}
+              <span aria-hidden>🌸</span>
+            </p>
           </figcaption>
         </figure>
         <figure className="space-y-2">
@@ -36,8 +51,23 @@ export function MothersDaySection({ date }: Props) {
               allowFullScreen
             />
           </div>
-          <figcaption className="text-xs text-fg/60">
-            Embedded via YouTube&apos;s privacy-enhanced player.
+          <figcaption className="space-y-1 text-xs text-fg/60">
+            <p>Embedded via YouTube&apos;s privacy-enhanced player.</p>
+            <p>
+              <span aria-hidden>🌸</span> nikkigirl, Big Ter,{' '}
+              <a className="underline" href="https://www.youtube.com/">
+                YouTube
+              </a>
+              ,{' '}
+              <a className="underline" href="https://www.python.org/">
+                Python
+              </a>
+              , &{' '}
+              <a className="underline" href="https://www.kapwing.com/">
+                Kapwing
+              </a>{' '}
+              <span aria-hidden>🌸</span>
+            </p>
           </figcaption>
         </figure>
       </div>

--- a/components/MothersDaySection.tsx
+++ b/components/MothersDaySection.tsx
@@ -1,0 +1,46 @@
+type Props = { date?: string };
+
+export function MothersDaySection({ date }: Props) {
+  return (
+    <section aria-label="Mother&apos;s Day 2025" className="space-y-2">
+      <h2 className="text-xl md:text-2xl font-semibold leading-snug">
+        <span aria-hidden>🌷</span>Mother&apos;s Day 2025{date ? `; ${date}` : ''}
+      </h2>
+      <p className="text-sm">
+        A heartfelt introduction will appear here when the time is right; for now please enjoy the videos below.
+      </p>
+      <div className="space-y-4">
+        <figure className="space-y-2">
+          <div className="yt-wrapper-bucks">
+            <iframe
+              src="https://www.youtube-nocookie.com/embed/br1qpJ2mCpE"
+              title="Mother&apos;s Day video 1"
+              loading="lazy"
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+              referrerPolicy="strict-origin-when-cross-origin"
+              allowFullScreen
+            />
+          </div>
+          <figcaption className="text-xs text-fg/60">
+            Embedded via YouTube&apos;s privacy-enhanced player.
+          </figcaption>
+        </figure>
+        <figure className="space-y-2">
+          <div className="yt-wrapper-bucks">
+            <iframe
+              src="https://www.youtube-nocookie.com/embed/n8fOQ4DOZTk"
+              title="Mother&apos;s Day video 2"
+              loading="lazy"
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+              referrerPolicy="strict-origin-when-cross-origin"
+              allowFullScreen
+            />
+          </div>
+          <figcaption className="text-xs text-fg/60">
+            Embedded via YouTube&apos;s privacy-enhanced player.
+          </figcaption>
+        </figure>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- feature Mother's Day 2025 section with placeholder intro and two video embeds
- document homepage sections in README quick notes

## Testing
- `npm run lint`
- `npm run typecheck`
- `TEST_DATABASE_URL=postgresql://localhost:5432/test npm test` *(fails: Jest encountered an unexpected token / missing Request)*

------
https://chatgpt.com/codex/tasks/task_e_68b93ea1e7bc832e8b8a8ada88c5b723