### PR TITLE
[WU-251] standardize card components

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ This keeps typography, colors, and spacing consistent across the site.
 
 ---
 
+## 🧩 UI Components
+
+Standard cards live in `components/ui/Card.tsx` and `components/ui/CardGroup.tsx`. `CardGroup` adds optional zebra striping with pure CSS.
+
+---
+
 ## 🖼️ Image Optimization Pipeline
 
 Optimize large images before pushing to the repo:

--- a/app/globals.css
+++ b/app/globals.css
@@ -59,6 +59,14 @@
   --success: var(--green);
   --warning: #92400e;
 
+  /* Card tokens */
+  --card-radius: 1rem;
+  --card-padding: 1rem;
+  --card-shadow: 0 1px 2px rgb(0 0 0 / 0.05);
+  --card-border-weight: 2px;
+  --card-border-color: var(--green);
+  --card-zebra-cream: var(--cream);
+
   /* Global badge tokens */
   --badge-classic-bg: #F0EBD2; /* Championship Gold */
   --badge-classic-fg: #00471B; /* Bucks Green */
@@ -282,6 +290,41 @@ p {
 
 .bucks-accent {
   color: var(--blue);
+}
+
+/* Card component */
+.card {
+  border-radius: var(--card-radius);
+  padding: var(--card-padding);
+  border: var(--card-border-weight) solid var(--card-border-color);
+  background: var(--surface-card);
+  box-shadow: var(--card-shadow);
+}
+
+.card-group > .card:nth-child(even):not([data-variant]) {
+  background: var(--card-zebra-cream);
+}
+
+.card[data-variant='brand'] {
+  background: var(--card-zebra-cream);
+  color: var(--bucks-green);
+}
+
+.card[data-variant='accent'] {
+  background: var(--blue);
+  color: var(--text-on-blue);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --card-zebra-cream: color-mix(in srgb, var(--surface) 85%, var(--cream));
+  }
+}
+
+@media (prefers-contrast: more) {
+  .card-group > .card:nth-child(even):not([data-variant]) {
+    background: var(--surface-card);
+  }
 }
 
 /* Standardized Radix Dialog styles */

--- a/app/heels-have-eyes/page.tsx
+++ b/app/heels-have-eyes/page.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import {
   Card,
-  CardGrid,
+  CardGroup,
   type CardItem,
   mapDomainToCardItem,
 } from "@ui"
@@ -122,7 +122,7 @@ export default function Page() {
 
           <div className="space-y-2">
             <h3 className="text-lg font-semibold">Albums to Explore</h3>
-            <CardGrid>
+            <CardGroup className="grid gap-3 sm:grid-cols-2">
               {items.map((item) => (
                 <Card key={item.id} className="relative">
                   <div className="flex items-start justify-between gap-3">
@@ -145,7 +145,7 @@ export default function Page() {
                   )}
                 </Card>
               ))}
-            </CardGrid>
+            </CardGroup>
           </div>
         </section>
       </article>

--- a/app/roadwork-rappin/page.tsx
+++ b/app/roadwork-rappin/page.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import {
   Card,
-  CardGrid,
+  CardGroup,
   type CardItem,
   mapDomainToCardItem,
 } from "@ui"
@@ -125,7 +125,7 @@ export default function Page() {
 
           <div className="space-y-2">
             <h3 className="text-lg font-semibold">Albums to Explore</h3>
-            <CardGrid>
+            <CardGroup className="grid gap-3 sm:grid-cols-2">
               {items.map((item) => (
                 <Card key={item.id} className="relative">
                   <div className="flex items-start justify-between gap-3">
@@ -148,7 +148,7 @@ export default function Page() {
                   )}
                 </Card>
               ))}
-            </CardGrid>
+            </CardGroup>
           </div>
         </section>
       </article>

--- a/components/ChroniclesSection.tsx
+++ b/components/ChroniclesSection.tsx
@@ -1,5 +1,6 @@
 import Image from 'next/image';
 import FlowersInline from '@/components/flowers/FlowersInline';
+import { Card, CardGroup } from '@ui';
 
 type Item = {
   slug: string;
@@ -118,20 +119,27 @@ export function ChroniclesSection({ date }: { date?: string }) {
       )}
 
       {/* Grid of cards with centered image as a grid item */}
-      <dl className="mt-4 grid grid-cols-1 md:grid-cols-3 gap-x-8 gap-y-4 md:gap-y-5 leading-6 md:leading-7">
+      <CardGroup
+        as="dl"
+        className="mt-4 grid grid-cols-1 md:grid-cols-3 gap-x-8 gap-y-4 md:gap-y-5 leading-6 md:leading-7"
+      >
         {/* First half of items */}
         {cards.slice(0, mid).map((it) => (
-          <div key={it.slug} id={it.slug} className="space-y-1 rounded-2xl border bg-card/50 p-4 shadow-sm">
+          <Card as="div" key={it.slug} id={it.slug} className="space-y-1">
             <dt className="flex items-baseline font-medium">
               <span aria-hidden className="mr-2 min-w-5 text-base">{it.icon}</span>
               <span>{it.title}</span>
             </dt>
             <dd className="text-sm md:text-[15px] text-muted-foreground">{it.body}</dd>
-          </div>
+          </Card>
         ))}
 
         {/* Center image card (placed at mid, centered column on md+) */}
-        <figure className="rounded-2xl border bg-card/50 p-2 shadow-sm place-self-center md:col-start-2">
+        <Card
+          as="figure"
+          variant="brand"
+          className="p-2 place-self-center md:col-start-2"
+        >
           <Image
             src="/images/optimized/raistlin black robes.webp"
             alt="Raistlin in black robes, atmospheric portrait"
@@ -141,19 +149,19 @@ export function ChroniclesSection({ date }: { date?: string }) {
             priority={false}
           />
           <figcaption className="sr-only">Raistlin illustration</figcaption>
-        </figure>
+        </Card>
 
         {/* Second half of items */}
         {cards.slice(mid).map((it) => (
-          <div key={it.slug} id={it.slug} className="space-y-1 rounded-2xl border bg-card/50 p-4 shadow-sm">
+          <Card as="div" key={it.slug} id={it.slug} className="space-y-1">
             <dt className="flex items-baseline font-medium">
               <span aria-hidden className="mr-2 min-w-5 text-base">{it.icon}</span>
               <span>{it.title}</span>
             </dt>
             <dd className="text-sm md:text-[15px] text-muted-foreground">{it.body}</dd>
-          </div>
+          </Card>
         ))}
-      </dl>
+      </CardGroup>
 
       {/* Outro bookend paragraph (Why it works) */}
       {why && (

--- a/components/scrolls/ReleaseCards.tsx
+++ b/components/scrolls/ReleaseCards.tsx
@@ -7,6 +7,7 @@ import { formatReleaseDate } from '@/app/(scrolls)/components/formatReleaseDate'
 import ScrollDialog from '@/app/(components)/shaolin/ScrollDialog';
 import { useScrollDialog } from '@/app/(components)/shaolin/useScrollDialog';
 import type { ReleaseRow } from './ReleasesTable';
+import { Card, CardGroup } from '@ui';
 
 export default function ReleaseCards({ rows }: { rows: ReleaseRow[] }) {
   const { open, setOpen, id, openWithId } = useScrollDialog();
@@ -29,12 +30,13 @@ export default function ReleaseCards({ rows }: { rows: ReleaseRow[] }) {
 
   return (
     <>
-      <ul className="space-y-3" data-testid="release-cards">
+      <CardGroup as="ul" className="space-y-3" data-testid="release-cards">
         {rows.map((r) => (
-          <li
+          <Card
+            as="li"
             key={r.id}
             data-testid="release-card"
-            className="rounded-xl border bucks-border p-3 bucks-surface"
+            className="text-[var(--bucks-green)]"
           >
             <div className="flex items-center justify-between">
               <a
@@ -56,9 +58,9 @@ export default function ReleaseCards({ rows }: { rows: ReleaseRow[] }) {
               <Badge className={getBadgeClass(r.status as any)}>{r.status}</Badge>
               <Badge className={getBadgeClass(r.type as any)}>{r.type}</Badge>
             </div>
-          </li>
+          </Card>
         ))}
-      </ul>
+      </CardGroup>
       <ScrollDialog open={open} onOpenChange={handleOpenChange} id={id} />
     </>
   );

--- a/components/ui/Card.tsx
+++ b/components/ui/Card.tsx
@@ -3,12 +3,20 @@ import { cn } from '@/lib/cn'
 
 export type CardProps = React.HTMLAttributes<HTMLElement> & {
   as?: React.ElementType
+  variant?: 'accent' | 'brand'
 }
 
-export function Card({ as: As = 'li', className, children, ...props }: CardProps) {
+export function Card({
+  as: As = 'li',
+  className,
+  variant,
+  children,
+  ...props
+}: CardProps) {
   return (
     <As
-      className={cn('rounded-2xl border border-border bg-surface p-4 shadow-sm', className)}
+      data-variant={variant}
+      className={cn('card', className)}
       {...props}
     >
       {children}

--- a/components/ui/CardGrid.tsx
+++ b/components/ui/CardGrid.tsx
@@ -1,9 +1,0 @@
-import React from 'react'
-
-export function CardGrid({ children }: { children: React.ReactNode }) {
-  return (
-    <ul role="list" className="grid gap-3 sm:grid-cols-2">
-      {children}
-    </ul>
-  )
-}

--- a/components/ui/CardGroup.tsx
+++ b/components/ui/CardGroup.tsx
@@ -1,0 +1,14 @@
+import React from 'react'
+import { cn } from '@/lib/cn'
+
+export type CardGroupProps = React.HTMLAttributes<HTMLElement> & {
+  as?: React.ElementType
+}
+
+export function CardGroup({ as: As = 'ul', className, children, ...props }: CardGroupProps) {
+  return (
+    <As className={cn('card-group', className)} {...props}>
+      {children}
+    </As>
+  )
+}

--- a/components/ui/index.ts
+++ b/components/ui/index.ts
@@ -13,6 +13,6 @@ export function mapDomainToCardItem<T>(items: T[], mapper: (item: T) => CardItem
 }
 
 export { Card } from './Card'
+export { CardGroup } from './CardGroup'
 // Re-export the canonical Badge to keep a single source of truth
 export { Badge } from '@/app/ui/Badge'
-export { CardGrid } from './CardGrid'


### PR DESCRIPTION
## Summary
- add Card and CardGroup components with design tokens for borders, surfaces, and zebra striping
- migrate existing cards to the shared components
- document UI components in README

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test` *(fails: Missing env var TEST_DATABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_68b93c65f6bc832e8c80c2c222ed452f