### PR TITLE
[WU-0005] Replace card class with Card component

### DIFF
--- a/app/ui-lab/DemoLab.tsx
+++ b/app/ui-lab/DemoLab.tsx
@@ -8,6 +8,7 @@ import SiteHeader from '@/components/SiteHeader';
 import Footer from '@/components/Footer';
 import AnnouncementBanner from '@/components/AnnouncementBanner';
 import Button from '@ui/Button';
+import { Card } from '@ui';
 
 const paletteTokens = {
   brand: [
@@ -50,11 +51,11 @@ export default function DemoLab() {
     <div className="mx-auto max-w-container space-y-8 p-4">
       <h1 className="text-4xl font-extrabold">UI Lab</h1>
       <div className="grid gap-6 md:grid-cols-2">
-        <section className="card space-y-4" aria-labelledby="flowers">
+        <Card as="section" className="space-y-4" aria-labelledby="flowers">
           <h2 id="flowers" className="text-xl font-semibold">Flowers</h2>
           <p><a href="/ui-lab/flowers" className="underline hover:no-underline">Open Flowers demo</a></p>
-        </section>
-        <section className="card space-y-4" aria-labelledby="announcement-banner">
+        </Card>
+        <Card as="section" className="space-y-4" aria-labelledby="announcement-banner">
           <h2 id="announcement-banner" className="text-xl font-semibold">Announcement Banner</h2>
           <div className="space-y-4">
             <div className="space-y-2">
@@ -118,24 +119,24 @@ export default function DemoLab() {
               </div>
             </div>
           </div>
-        </section>
-        <section className="card space-y-4" aria-labelledby="header-footer">
+        </Card>
+        <Card as="section" className="space-y-4" aria-labelledby="header-footer">
           <h2 id="header-footer" className="text-xl font-semibold">Header & Footer</h2>
           <div className="border border-border-subtle rounded">
             <SiteHeader />
             <div className="p-4 text-center">Page content</div>
             <Footer />
           </div>
-        </section>
-        <section className="card space-y-4" aria-labelledby="callout">
+        </Card>
+        <Card as="section" className="space-y-4" aria-labelledby="callout">
           <h2 id="callout" className="text-xl font-semibold">Callout</h2>
           <Callout>Remember to stay hydrated.</Callout>
-        </section>
-        <section className="card space-y-4" aria-labelledby="quote">
+        </Card>
+        <Card as="section" className="space-y-4" aria-labelledby="quote">
           <h2 id="quote" className="text-xl font-semibold">Quote</h2>
           <Quote cite="tullyelly">Design is both art and science.</Quote>
-        </section>
-        <section className="card space-y-4 md:col-span-2" aria-labelledby="hero">
+        </Card>
+        <Card as="section" className="space-y-4 md:col-span-2" aria-labelledby="hero">
           <h2 id="hero" className="text-xl font-semibold">Hero</h2>
           <div className="flex flex-col-reverse items-center gap-6 md:flex-row md:gap-8">
             <div className="space-y-4 text-center md:text-left">
@@ -161,8 +162,8 @@ export default function DemoLab() {
             />
             Show image
           </label>
-        </section>
-        <section className="card space-y-4 md:col-span-2" aria-labelledby="palette">
+        </Card>
+        <Card as="section" className="space-y-4 md:col-span-2" aria-labelledby="palette">
           <h2 id="palette" className="text-xl font-semibold">Palette</h2>
           <label className="inline-flex items-center gap-2 text-sm">
             Palette
@@ -189,7 +190,7 @@ export default function DemoLab() {
               </li>
             ))}
           </ul>
-        </section>
+        </Card>
       </div>
     </div>
   );

--- a/app/ui-lab/FlowersDemo.tsx
+++ b/app/ui-lab/FlowersDemo.tsx
@@ -1,9 +1,10 @@
 import FlowersInline from "@/components/flowers/FlowersInline";
 import FlowersBlock from "@/components/flowers/FlowersBlock";
+import { Card } from "@ui";
 
 export default function FlowersDemo() {
   return (
-    <section className="card space-y-3" aria-labelledby="flowers-demo">
+    <Card as="section" className="space-y-3" aria-labelledby="flowers-demo">
       <h2 id="flowers-demo" className="text-xl font-semibold">Flowers</h2>
       <p className="text-sm text-muted-foreground">Screen readers announce &quot;Acknowledgments&quot;; the emoji is aria-hidden.</p>
       <div className="space-y-2">
@@ -16,6 +17,6 @@ export default function FlowersDemo() {
           <span key="2">Chronicles wiki &amp; Raistlin Majere</span>,
         ]}
       />
-    </section>
+    </Card>
   );
 }

--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -14,7 +14,7 @@ The `/ui-lab` page showcases design tokens and reusable components.
 
 ### Adding a demo tile
 
-1. Edit `app/ui-lab/DemoLab.tsx` and insert a new `<section>` with the `card` class and a unique heading referenced by
+1. Edit `app/ui-lab/DemoLab.tsx` and insert a new `<Card as="section" className="space-y-4">` tile (import `Card` from `@ui`) with a unique heading referenced by
    `aria-labelledby`.
 2. Use theme tokens via Tailwind utilities; avoid inline styles.
 3. Offer preset examples and, when helpful, controls that let visitors tweak props live.

--- a/docs/palette-demo.html
+++ b/docs/palette-demo.html
@@ -6,7 +6,6 @@
   <link rel="stylesheet" href="../app/globals.css" />
   <style>
     .demo-grid { display: flex; flex-wrap: wrap; gap: 1rem; }
-    .card { width: 280px; }
   </style>
 </head>
 <body>
@@ -15,21 +14,21 @@
     <p>This page shows usage of the Milwaukee Bucks Cream City color tokens.</p>
 
     <div class="demo-grid">
-      <div class="card">
+      <div class="rounded-2xl bg-white p-4 border-2 border-brand-bucksGreen shadow-sm" style="width:280px">
         <h2>Card Heading</h2>
         <p>Body text on white surface. <a href="#">Link example</a>.</p>
         <button class="inline-block px-4 py-2 rounded font-semibold cursor-pointer bg-blue text-text-on-blue hover:brightness-90">Primary</button>
         <button class="inline-block px-4 py-2 rounded font-semibold cursor-pointer bg-green text-text-on-green hover:brightness-90">Secondary</button>
       </div>
 
-      <div class="card on-cream">
+      <div class="rounded-2xl p-4 border-2 border-brand-bucksGreen shadow-sm on-cream" style="width:280px">
         <h2>Cream Surface</h2>
         <p>Links adapt color: <a href="#">example link</a>.</p>
       </div>
 
       <div class="alert">This is an alert using Bucks Green.</div>
 
-      <form class="card">
+      <form class="rounded-2xl bg-white p-4 border-2 border-brand-bucksGreen shadow-sm" style="width:280px">
         <label for="name">Name</label>
         <input id="name" placeholder="Your name" />
         <label for="state">State</label>


### PR DESCRIPTION
## Summary
- route UI lab sections through the shared `Card` wrapper
- document the `Card` component usage and drop the old `.card` class
- inline Tailwind classes in the palette demo

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test` *(fails: Missing env var: TEST_DATABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_68ba5cd50f14832eaba29f76ae54e98a