### PR TITLE
[WU-175] prune unused tailwind color tokens

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -10,8 +10,7 @@
   --cream: #EEE1C6;            /* Cream City Cream */
   --white: #FFFFFF;
   --ink: #0C1B0C;              /* near-black text */
-  --green-900: #00471B;        /* Bucks Green (header badges etc.) */
-  --bucks-green: var(--green-900);
+  --bucks-green: #00471B;      /* Bucks Green (header badges etc.) */
   --gold: #F0EBD2;
   --font-inter: system-ui, sans-serif;
   --font-jbmono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -20,15 +19,10 @@
   --brand-chrome: #0077C0;      /* Great Lakes Blue */
   --brand-chrome-fg: #ffffff;   /* text on chrome */
 
-  /* Brand semantic tokens (single source of truth) */
-  --brand-primary: #0077C0;     /* Great Lakes Blue */
-  --brand-primary-contrast: #0069A9; /* slightly darker for contrast uses */
-  --brand-divider: var(--brand-primary); /* used for thin separators */
-
   /* Brand bases */
   --blue: #0077C0;             /* Great Lakes Blue */
   --blue-contrast: #0069A9;    /* Darkened for AA on cream */
-  --green: var(--green-900);   /* Bucks Green */
+  --green: #00471B;            /* Bucks Green */
   --header-focus: color-mix(in srgb, white 85%, var(--brand-chrome));
 
   /* Neutrals for readability */
@@ -56,15 +50,12 @@
 
   /* UI tokens */
   --surface: var(--surface-card);
-  --bg: var(--surface-page);
   --border: var(--border-subtle);
   --fg: var(--text-primary);
-  --success: var(--green);
-  --warning: #92400e;
 
   /* Global badge tokens */
   --badge-classic-bg: #F0EBD2; /* Championship Gold */
-  --badge-classic-fg: var(--green-900); /* Bucks Green */
+  --badge-classic-fg: #00471B; /* Bucks Green */
   --badge-classic-ring: rgba(0, 71, 27, 0.25);
 }
 

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -1,6 +1,4 @@
 // Tailwind v4 — ESM config
-import plugin from 'tailwindcss/plugin'
-
 export default {
   content: [
     "./app/**/*.{js,jsx,ts,tsx,mdx}",
@@ -15,7 +13,6 @@ export default {
         blue: "var(--blue)",
         "blue-contrast": "var(--blue-contrast)",
         green: "var(--green)",
-        "green-900": "var(--green-900)",
         white: "var(--white)",
         black: "var(--black)",
         ink: "var(--ink)",
@@ -28,30 +25,12 @@ export default {
         "surface-card": "var(--surface-card)",
         "border-subtle": "var(--border-subtle)",
         surface: "var(--surface)",
-        bg: "var(--bg)",
         border: "var(--border)",
         fg: "var(--fg)",
-        success: "var(--success)",
-        warning: "var(--warning)",
-        brandPrimary: "var(--brand-primary)",
-        brandDivider: "var(--brand-divider)",
         brand: {
           bucksGreen: '#00471B',
           creamCityCream: '#EEE1C6',
           greatLakesBlue: '#0077C0',
-          championshipGold: '#F0EBD2',
-          red: '#C8102E',
-          border: 'var(--border, #e5e7eb)',
-          card: 'var(--card, #ffffff)',
-        },
-        badge: {
-          planned: 'var(--badge-planned, #0077C0)',
-          released: 'var(--badge-released, #16a34a)',
-          minor: 'var(--badge-minor, #16a34a)',
-          hotfix: 'var(--badge-hotfix, #C8102E)',
-          archived: 'var(--badge-archived, #E9D8C7)',
-          patch: 'var(--badge-patch, #F0EBD2)',
-          neutral: 'var(--badge-neutral, #64748b)',
         },
       },
       maxWidth: {
@@ -77,32 +56,7 @@ export default {
           "monospace",
         ],
       },
-      borderRadius: {
-        badge: '9999px',
-      },
     },
   },
-  plugins: [
-    plugin(function ({ addComponents, theme }) {
-      addComponents({
-        '.badge': {
-          display: 'inline-flex',
-          alignItems: 'center',
-          gap: '0.375rem',
-          padding: '0.25rem 0.5rem',
-          borderRadius: theme('borderRadius.badge'),
-          fontSize: '0.875rem',
-          fontWeight: '600',
-          lineHeight: '1.25rem',
-        },
-        '.badge--planned': { backgroundColor: theme('colors.badge.planned'), color: '#fff' },
-        '.badge--released': { backgroundColor: theme('colors.badge.released'), color: '#fff' },
-        '.badge--minor': { backgroundColor: theme('colors.badge.minor'), color: '#fff' },
-        '.badge--hotfix': { backgroundColor: theme('colors.badge.hotfix'), color: '#fff' },
-        '.badge--archived': { backgroundColor: theme('colors.badge.archived'), color: '#111827' },
-        '.badge--patch': { backgroundColor: theme('colors.badge.patch'), color: '#111827' },
-        '.badge--neutral': { backgroundColor: theme('colors.badge.neutral'), color: '#fff' },
-      })
-    }),
-  ],
+  plugins: [],
 };


### PR DESCRIPTION
## Summary
- remove unused Tailwind color tokens and badge plugin
- trim matching :root CSS variables

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test` *(fails: Missing env var TEST_DATABASE_URL)*
- `npm run build` *(fails: Failed to collect page data for /api/releases-count)*

------
https://chatgpt.com/codex/tasks/task_e_68ba5ce57cbc832e9575810697a38d46